### PR TITLE
release: sign artifacts with cosign, add SBOMs and provenance attestations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,9 +18,12 @@ permissions:
 
 env:
   REGISTRY: ghcr.io
-  MANAGER_IMAGE: ghcr.io/${{ toLower(github.repository_owner) }}/declarative-conversion-operator
-  WEBHOOK_SERVER_IMAGE: ghcr.io/${{ toLower(github.repository_owner) }}/declarative-conversion-webhook-server
-  CHART_REPO: ghcr.io/${{ toLower(github.repository_owner) }}/charts
+  # ghcr.io requires lowercase paths; github.repository_owner is "TeraSky-OSS"
+  # (mixed case), so this is hardcoded lowercase rather than derived, same as
+  # matrix.image below.
+  MANAGER_IMAGE: ghcr.io/terasky-oss/declarative-conversion-operator
+  WEBHOOK_SERVER_IMAGE: ghcr.io/terasky-oss/declarative-conversion-webhook-server
+  CHART_REPO: ghcr.io/terasky-oss/charts
 
 jobs:
   test:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,6 @@ on:
 permissions:
   contents: write
   packages: write
-  id-token: write # keyless cosign signing + GitHub attestations (OIDC)
-  attestations: write # actions/attest-build-provenance, actions/attest-sbom
 
 env:
   REGISTRY: ghcr.io
@@ -34,6 +32,11 @@ jobs:
     name: Build & push ${{ matrix.component }} image
     runs-on: ubuntu-latest
     needs: test
+    permissions:
+      contents: read
+      packages: write
+      id-token: write # keyless cosign signing + GitHub attestations (OIDC)
+      attestations: write # actions/attest-build-provenance, actions/attest-sbom
     strategy:
       fail-fast: false
       matrix:
@@ -126,6 +129,11 @@ jobs:
     name: Package & push Helm chart
     runs-on: ubuntu-latest
     needs: images
+    permissions:
+      contents: read
+      packages: write
+      id-token: write # keyless cosign signing + GitHub attestations (OIDC)
+      attestations: write # actions/attest-build-provenance
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -201,6 +209,10 @@ jobs:
     name: Release CLI binaries (GoReleaser)
     runs-on: ubuntu-latest
     needs: test
+    permissions:
+      contents: write # goreleaser creates the GitHub release and uploads assets
+      id-token: write # keyless cosign signing + GitHub attestations (OIDC)
+      attestations: write # actions/attest-build-provenance
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -259,7 +271,7 @@ jobs:
             echo ""
             echo "## Signed artifacts"
             echo ""
-            echo "The container images and Helm chart below are signed keylessly with [cosign](https://github.com/sigstore/cosign) using this workflow's GitHub OIDC identity, and carry [GitHub build provenance](https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds) and SBOM attestations. The CLI \`checksums.txt\` (covering all archives) is likewise cosign-signed and carries a build provenance attestation; each archive has an accompanying SBOM."
+            echo "The container images and Helm chart below are signed keylessly with [cosign](https://github.com/sigstore/cosign) using this workflow's GitHub OIDC identity, and carry a [GitHub build provenance attestation](https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds). The container images additionally carry an SBOM attestation (the Helm chart does not — it has no dependency graph of its own). The CLI \`checksums.txt\` (covering all archives) is likewise cosign-signed and carries a build provenance attestation; each archive has an accompanying SBOM."
             echo ""
             echo "| Artifact | Digest |"
             echo "|---|---|"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,12 +13,14 @@ on:
 permissions:
   contents: write
   packages: write
+  id-token: write # keyless cosign signing + GitHub attestations (OIDC)
+  attestations: write # actions/attest-build-provenance, actions/attest-sbom
 
 env:
   REGISTRY: ghcr.io
-  MANAGER_IMAGE: ghcr.io/${{ github.repository_owner }}/declarative-conversion-operator
-  WEBHOOK_SERVER_IMAGE: ghcr.io/${{ github.repository_owner }}/declarative-conversion-webhook-server
-  CHART_REPO: ghcr.io/${{ github.repository_owner }}/charts
+  MANAGER_IMAGE: ghcr.io/${{ toLower(github.repository_owner) }}/declarative-conversion-operator
+  WEBHOOK_SERVER_IMAGE: ghcr.io/${{ toLower(github.repository_owner) }}/declarative-conversion-webhook-server
+  CHART_REPO: ghcr.io/${{ toLower(github.repository_owner) }}/charts
 
 jobs:
   test:
@@ -54,6 +56,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
       - name: Derive metadata
         id: meta
         uses: docker/metadata-action@v6
@@ -65,6 +70,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push
+        id: build
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -77,6 +83,41 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Sign image (cosign keyless)
+        run: cosign sign --yes "${{ matrix.image }}@${{ steps.build.outputs.digest }}"
+
+      - name: Generate image SBOM
+        uses: anchore/sbom-action@v0
+        with:
+          image: ${{ matrix.image }}@${{ steps.build.outputs.digest }}
+          format: spdx-json
+          output-file: sbom-${{ matrix.component }}.spdx.json
+          artifact-name: sbom-${{ matrix.component }}.spdx.json
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ matrix.image }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
+
+      - name: Attest SBOM
+        uses: actions/attest-sbom@v2
+        with:
+          subject-name: ${{ matrix.image }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          sbom-path: sbom-${{ matrix.component }}.spdx.json
+          push-to-registry: true
+
+      - name: Record image digest
+        run: echo "${{ matrix.image }}@${{ steps.build.outputs.digest }}" > digest.txt
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v7
+        with:
+          name: digest-${{ matrix.component }}
+          path: digest.txt
 
   helm-chart:
     name: Package & push Helm chart
@@ -102,14 +143,56 @@ jobs:
           sed -i "s/^version: .*/version: ${version}/" charts/declarative-conversion-operator/Chart.yaml
           sed -i "s/^appVersion: .*/appVersion: \"${version}\"/" charts/declarative-conversion-operator/Chart.yaml
 
-      - name: Log in to GHCR
+      - name: Log in to GHCR (docker)
+        # cosign and the attestation actions read registry credentials from
+        # ~/.docker/config.json, which `helm registry login` alone does not
+        # populate (it writes to helm's own credentials file instead), so we
+        # also log in via docker/login-action.
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to GHCR (helm)
         run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
 
       - name: Package chart
         run: helm package charts/declarative-conversion-operator --destination /tmp/chart-out
 
       - name: Push chart to GHCR (OCI)
-        run: helm push /tmp/chart-out/*.tgz oci://${{ env.CHART_REPO }}
+        id: push
+        run: |
+          out="$(helm push /tmp/chart-out/*.tgz "oci://${CHART_REPO}" 2>&1 | tee /dev/stderr)"
+          digest="$(printf '%s\n' "$out" | grep -oE 'sha256:[0-9a-f]{64}')"
+          if [ -z "$digest" ]; then
+            echo "could not determine chart digest from helm push output" >&2
+            exit 1
+          fi
+          echo "digest=${digest}" >> "$GITHUB_OUTPUT"
+          echo "ref=${CHART_REPO}/declarative-conversion-operator" >> "$GITHUB_OUTPUT"
+
+      - name: Sign chart (cosign keyless)
+        run: cosign sign --yes "${{ steps.push.outputs.ref }}@${{ steps.push.outputs.digest }}"
+
+      - name: Attest chart build provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ steps.push.outputs.ref }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+
+      - name: Record chart digest
+        run: echo "${{ steps.push.outputs.ref }}@${{ steps.push.outputs.digest }}" > digest.txt
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v7
+        with:
+          name: digest-chart
+          path: digest.txt
 
   cli:
     name: Release CLI binaries (GoReleaser)
@@ -127,6 +210,12 @@ jobs:
           go-version-file: go.mod
           cache: true
 
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Install syft
+        uses: anchore/sbom-action/download-syft@v0
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7
         with:
@@ -135,3 +224,74 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Attest CLI artifact build provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: |
+            dist/*.tar.gz
+            dist/*.zip
+            dist/checksums.txt
+
+  publish-release:
+    name: Publish signed-artifact summary to the release
+    runs-on: ubuntu-latest
+    needs: [cli, images, helm-chart]
+    steps:
+      - name: Download image/chart digests
+        uses: actions/download-artifact@v7
+        with:
+          pattern: digest-*
+          path: digests
+
+      - name: Download image SBOMs
+        uses: actions/download-artifact@v7
+        with:
+          pattern: sbom-*
+          path: sboms
+
+      - name: Build release notes addendum
+        run: |
+          {
+            echo ""
+            echo "## Signed artifacts"
+            echo ""
+            echo "The container images and Helm chart below are signed keylessly with [cosign](https://github.com/sigstore/cosign) using this workflow's GitHub OIDC identity, and carry [GitHub build provenance](https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds) and SBOM attestations. The CLI \`checksums.txt\` (covering all archives) is likewise cosign-signed and carries a build provenance attestation; each archive has an accompanying SBOM."
+            echo ""
+            echo "| Artifact | Digest |"
+            echo "|---|---|"
+            for f in digests/digest-*/digest.txt; do
+              ref="$(cat "$f")"
+              echo "| \`${ref%%@*}\` | \`${ref##*@}\` |"
+            done
+            echo ""
+            echo "#### Verify a container image or the Helm chart"
+            echo ""
+            echo '```bash'
+            echo "cosign verify \\"
+            echo "  --certificate-identity-regexp '^https://github.com/terasky-oss/declarative-conversion-operator/\\.github/workflows/release\\.yml@refs/tags/.*\$' \\"
+            echo "  --certificate-oidc-issuer https://token.actions.githubusercontent.com \\"
+            echo "  <artifact>@<digest>"
+            echo ""
+            echo "gh attestation verify oci://<artifact>@<digest> --owner terasky-oss"
+            echo '```'
+            echo ""
+            echo "#### Verify the CLI checksums (and, transitively, the archives)"
+            echo ""
+            echo '```bash'
+            echo "cosign verify-blob \\"
+            echo "  --certificate checksums.txt.pem \\"
+            echo "  --signature checksums.txt.sig \\"
+            echo "  --certificate-identity-regexp '^https://github.com/terasky-oss/declarative-conversion-operator/\\.github/workflows/release\\.yml@refs/tags/.*\$' \\"
+            echo "  --certificate-oidc-issuer https://token.actions.githubusercontent.com \\"
+            echo "  checksums.txt"
+            echo '```'
+          } > addendum.md
+
+      - name: Update release with signed-artifact details
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          append_body: true
+          body_path: addendum.md
+          files: sboms/**/*.json

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -30,6 +30,27 @@ archives:
 checksum:
   name_template: "checksums.txt"
 
+sboms:
+  # One CycloneDX SBOM per archive (${artifact}.sbom); requires syft on PATH
+  # (installed via anchore/sbom-action/download-syft in the release workflow).
+  - artifacts: archive
+
+signs:
+  # Keyless-sign checksums.txt with cosign, using the workflow's GitHub OIDC
+  # identity (needs id-token: write and cosign on PATH). Verifying the
+  # checksum file's signature and matching an archive's hash against it
+  # verifies that archive, so we don't need to sign every archive individually.
+  - cmd: cosign
+    signature: "${artifact}.sig"
+    certificate: "${artifact}.pem"
+    args:
+      - sign-blob
+      - "--yes"
+      - "--output-signature=${signature}"
+      - "--output-certificate=${certificate}"
+      - "${artifact}"
+    artifacts: checksum
+
 changelog:
   sort: asc
   use: git
@@ -53,4 +74,6 @@ release:
 
     Container images: `ghcr.io/terasky-oss/declarative-conversion-operator:{{ .Tag }}` and `ghcr.io/terasky-oss/declarative-conversion-webhook-server:{{ .Tag }}`.
     Helm chart: `oci://ghcr.io/terasky-oss/charts/declarative-conversion-operator --version {{ .Version }}`.
+
+    `checksums.txt` below is signed keylessly with [cosign](https://github.com/sigstore/cosign) (`checksums.txt.sig` / `checksums.txt.pem`) using this workflow's GitHub OIDC identity, and each archive has an accompanying CycloneDX SBOM (`*.sbom`). See the "Signed artifacts" section further down for verification commands and container image/Helm chart digests.
   prerelease: auto

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -33,7 +33,12 @@ checksum:
 sboms:
   # One CycloneDX SBOM per archive (${artifact}.sbom); requires syft on PATH
   # (installed via anchore/sbom-action/download-syft in the release workflow).
+  # GoReleaser's own default is spdx-json, so the format is set explicitly.
   - artifacts: archive
+    args:
+      - "$artifact"
+      - "--output"
+      - "cyclonedx-json=$document"
 
 signs:
   # Keyless-sign checksums.txt with cosign, using the workflow's GitHub OIDC


### PR DESCRIPTION
- Container images (manager, webhook-server) and the Helm chart are now
  keylessly signed with cosign after push, with GitHub build-provenance and
  SBOM (SPDX) attestations recorded and pushed to the registry as referrers.
- GoReleaser now generates a CycloneDX SBOM per CLI archive and cosign-signs
  checksums.txt (covering all archives), plus a build-provenance attestation
  over the CLI artifacts.
- A new publish-release job appends artifact digests, verification commands,
  and the image SBOMs to the GitHub release GoReleaser already creates.
- Fixed CHART_REPO/MANAGER_IMAGE/WEBHOOK_SERVER_IMAGE to lowercase the GitHub
  org name (ghcr.io requires lowercase paths; the org is TeraSky-OSS).
- Added id-token: write and attestations: write permissions needed for
  keyless signing and GitHub attestations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Release artifacts now include signed checksums and per-archive SBOMs.
  - Container images and Helm charts include signed provenance and SBOM attestations.
  - CLI artifacts include attestations to support origin and integrity verification.
  - Release pages provide verification details and downloadable SBOM files.

- **Documentation**
  - Release information now describes signed checksums, provenance attestations, and archive-level SBOM availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->