### PR TITLE
test: substantially increase unit test coverage across the operator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,27 @@ jobs:
         run: go build ./...
 
       - name: go test (race, coverage)
-        run: go test ./... -race -count=1 -coverprofile=coverage.out
+        # -coverpkg=./... attributes coverage to the package a statement
+        # actually lives in, even when it's only ever exercised by a test in
+        # a *different* package (e.g. api/v1alpha1's rule-conversion logic,
+        # called from internal/webhook and internal/cli's tests). Without
+        # it, go test's default same-package-only accounting understates
+        # real coverage for exactly that kind of library code.
+        run: go test ./... -race -count=1 -coverpkg=./... -coverprofile=coverage.out
+
+      - name: Enforce minimum coverage
+        run: |
+          total="$(go tool cover -func=coverage.out | tail -1 | awk '{print $NF}' | tr -d '%')"
+          echo "Total coverage: ${total}%"
+          # 60% leaves headroom below the ~65% this suite currently
+          # achieves, so incidental drift doesn't fail CI, while still
+          # catching a real regression (e.g. a large chunk of untested code
+          # landing, or tests being deleted rather than fixed).
+          threshold=60
+          if awk -v t="$total" -v m="$threshold" 'BEGIN { exit !(t < m) }'; then
+            echo "Coverage ${total}% is below the ${threshold}% minimum."
+            exit 1
+          fi
 
       - name: Upload coverage
         uses: actions/upload-artifact@v7

--- a/api/v1alpha1/xrdconversionconfig_convert_test.go
+++ b/api/v1alpha1/xrdconversionconfig_convert_test.go
@@ -1,0 +1,396 @@
+/*
+Copyright 2026 The declarative-conversion-operator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"strings"
+	"testing"
+
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+
+	"github.com/terasky-oss/declarative-conversion-operator/pkg/engine"
+)
+
+// rawJSON builds an extv1.JSON from a literal JSON snippet, panicking on a
+// malformed literal (a test-authoring bug, not a case under test).
+func rawJSON(literal string) extv1.JSON {
+	return extv1.JSON{Raw: []byte(literal)}
+}
+
+// wellFormedRules returns one syntactically valid ConversionRule per
+// strategy, keyed by strategy — the fixture both the happy-path and the
+// nil-params-error tables below mutate.
+func wellFormedRules() map[Strategy]ConversionRule {
+	return map[Strategy]ConversionRule{
+		StrategyFieldRename: {
+			Strategy:    StrategyFieldRename,
+			FieldRename: &FieldRenameParams{HubPath: "spec.size", SpokePath: "spec.storageSize"},
+		},
+		StrategyScalarToObject: {
+			Strategy: StrategyScalarToObject,
+			ScalarToObject: &ScalarToObjectParams{
+				HubPath: "spec.size", SpokePath: "spec.storage", Key: "value",
+				DefaultsForOtherKeys: map[string]extv1.JSON{"unit": rawJSON(`"Gi"`)},
+			},
+		},
+		StrategyObjectToScalar: {
+			Strategy: StrategyObjectToScalar,
+			ObjectToScalar: &ObjectToScalarParams{
+				HubPath: "spec.storage", SpokePath: "spec.size", Key: "value",
+				DefaultsForOtherKeys: map[string]extv1.JSON{"unit": rawJSON(`"Gi"`)},
+			},
+		},
+		StrategySingletonArrayToObject: {
+			Strategy:               StrategySingletonArrayToObject,
+			SingletonArrayToObject: &SingletonArrayToObjectParams{HubPath: "spec.items", SpokePath: "spec.item"},
+		},
+		StrategyObjectToSingletonArray: {
+			Strategy:               StrategyObjectToSingletonArray,
+			ObjectToSingletonArray: &ObjectToSingletonArrayParams{HubPath: "spec.item", SpokePath: "spec.items"},
+		},
+		StrategyFieldsToMap: {
+			Strategy: StrategyFieldsToMap,
+			FieldsToMap: &FieldsToMapParams{
+				HubPaths: []string{"spec.a", "spec.b"}, SpokeMapPath: "spec.m",
+				KeyNames: map[string]string{"spec.a": "a", "spec.b": "b"},
+			},
+		},
+		StrategyMapToFields: {
+			Strategy: StrategyMapToFields,
+			MapToFields: &MapToFieldsParams{
+				HubMapPath: "spec.m", SpokePaths: []string{"spec.a", "spec.b"},
+				KeyNames: map[string]string{"spec.a": "a", "spec.b": "b"},
+			},
+		},
+		StrategyToAnnotation: {
+			Strategy:     StrategyToAnnotation,
+			ToAnnotation: &ToMetadataParams{HubPath: "spec.extra", Key: "example.org/extra"},
+		},
+		StrategyToLabel: {
+			Strategy: StrategyToLabel,
+			ToLabel:  &ToMetadataParams{HubPath: "spec.tier", Key: "example.org/tier"},
+		},
+		StrategyEnumRemap: {
+			Strategy: StrategyEnumRemap,
+			EnumRemap: &EnumRemapParams{
+				Path:    "spec.tier",
+				Mapping: []EnumValueMapping{{Hub: "Standard", Spoke: "std"}, {Hub: "Premium", Spoke: "prem"}},
+			},
+		},
+		StrategyDefaultValue: {
+			Strategy:     StrategyDefaultValue,
+			DefaultValue: &DefaultValueParams{Path: "spec.tier", ExistsOn: SideSpoke, Default: rawJSON(`"Standard"`)},
+		},
+		StrategyConstant: {
+			Strategy: StrategyConstant,
+			Constant: &ConstantParams{Path: "spec.kind", ExistsOn: SideHub, Value: rawJSON(`"fixed"`)},
+		},
+		StrategyDelete: {
+			Strategy: StrategyDelete,
+			Delete:   &DeleteParams{Path: "spec.legacy", ExistsOn: SideHub},
+		},
+		StrategyJSONPatch: {
+			Strategy: StrategyJSONPatch,
+			JSONPatch: &JSONPatchParams{
+				HubToSpoke: []JSONPatchOp{{Op: "add", Path: "/spec/flag", Value: ptrJSON(rawJSON("true"))}},
+				SpokeToHub: []JSONPatchOp{{Op: "remove", Path: "/spec/flag"}},
+			},
+		},
+		StrategyForEach: {
+			Strategy: StrategyForEach,
+			ForEach: &ForEachParams{
+				HubItemsPath: "spec.items", SpokeItemsPath: "spec.items",
+				Rules: []ConversionRule{{
+					Strategy:    StrategyFieldRename,
+					FieldRename: &FieldRenameParams{HubPath: "name", SpokePath: "id"},
+				}},
+			},
+		},
+		StrategyTypeCoerce: {
+			Strategy:   StrategyTypeCoerce,
+			TypeCoerce: &TypeCoerceParams{Path: "spec.count"},
+		},
+		StrategyScalarToFields: {
+			Strategy: StrategyScalarToFields,
+			ScalarToFields: &ScalarToFieldsParams{
+				HubPath: "spec.size", Pattern: `^(?P<value>\d+)(?P<unit>[A-Za-z]+)$`,
+				SpokeFields:  map[string]string{"value": "spec.sizeValue", "unit": "spec.sizeUnit"},
+				JoinTemplate: "{{.value}}{{.unit}}",
+			},
+		},
+		StrategyFieldsToScalar: {
+			Strategy: StrategyFieldsToScalar,
+			FieldsToScalar: &FieldsToScalarParams{
+				HubFields: map[string]string{"value": "spec.sizeValue", "unit": "spec.sizeUnit"},
+				Pattern:   `^(?P<value>\d+)(?P<unit>[A-Za-z]+)$`, SpokePath: "spec.size",
+				JoinTemplate: "{{.value}}{{.unit}}",
+			},
+		},
+		StrategyArrayToMapByKey: {
+			Strategy:        StrategyArrayToMapByKey,
+			ArrayToMapByKey: &ArrayToMapByKeyParams{HubPath: "spec.list", SpokePath: "spec.map", KeyField: "name"},
+		},
+		StrategyMapToArrayByKey: {
+			Strategy:        StrategyMapToArrayByKey,
+			MapToArrayByKey: &MapToArrayByKeyParams{HubPath: "spec.map", SpokePath: "spec.list", KeyField: "name"},
+		},
+		StrategyNumericScale: {
+			Strategy:     StrategyNumericScale,
+			NumericScale: &NumericScaleParams{HubPath: "spec.bytes", SpokePath: "spec.kilobytes", Factor: 0.001},
+		},
+		StrategyListJoin: {
+			Strategy: StrategyListJoin,
+			ListJoin: &ListJoinParams{HubPath: "spec.tags", SpokePath: "spec.tagsCSV", Separator: ","},
+		},
+		StrategyListSplit: {
+			Strategy:  StrategyListSplit,
+			ListSplit: &ListSplitParams{HubPath: "spec.tagsCSV", SpokePath: "spec.tags", Separator: ","},
+		},
+	}
+}
+
+func ptrJSON(j extv1.JSON) *extv1.JSON { return &j }
+
+// clearParams returns a copy of rule with every strategy-specific params
+// pointer nilled out, simulating a rule whose declared strategy doesn't
+// match any populated params field (the "requires X params" error path).
+func clearParams(rule ConversionRule) ConversionRule {
+	rule.FieldRename = nil
+	rule.ScalarToObject = nil
+	rule.ObjectToScalar = nil
+	rule.SingletonArrayToObject = nil
+	rule.ObjectToSingletonArray = nil
+	rule.FieldsToMap = nil
+	rule.MapToFields = nil
+	rule.ToAnnotation = nil
+	rule.ToLabel = nil
+	rule.EnumRemap = nil
+	rule.DefaultValue = nil
+	rule.Constant = nil
+	rule.Delete = nil
+	rule.JSONPatch = nil
+	rule.ForEach = nil
+	rule.TypeCoerce = nil
+	rule.ScalarToFields = nil
+	rule.FieldsToScalar = nil
+	rule.ArrayToMapByKey = nil
+	rule.MapToArrayByKey = nil
+	rule.NumericScale = nil
+	rule.ListJoin = nil
+	rule.ListSplit = nil
+	return rule
+}
+
+func TestConvertRules_HappyPathPerStrategy(t *testing.T) {
+	for strategy, rule := range wellFormedRules() {
+		t.Run(string(strategy), func(t *testing.T) {
+			out, err := convertRules([]ConversionRule{rule})
+			if err != nil {
+				t.Fatalf("unexpected error for a well-formed %s rule: %v", strategy, err)
+			}
+			if len(out) != 1 {
+				t.Fatalf("expected exactly one converted rule, got %d", len(out))
+			}
+			if out[0].Strategy != engine.Strategy(strategy) {
+				t.Fatalf("expected engine strategy %q, got %q", strategy, out[0].Strategy)
+			}
+			if out[0].Params == nil {
+				t.Fatalf("expected non-nil params for %s", strategy)
+			}
+		})
+	}
+}
+
+func TestConvertRules_MissingParamsErrorsPerStrategy(t *testing.T) {
+	for strategy, rule := range wellFormedRules() {
+		t.Run(string(strategy), func(t *testing.T) {
+			bare := clearParams(rule)
+			_, err := convertRules([]ConversionRule{bare})
+			if err == nil {
+				t.Fatalf("expected an error when %s's params field is nil", strategy)
+			}
+			if !strings.Contains(err.Error(), string(strategy)) {
+				t.Fatalf("expected the error to name the strategy %q, got: %v", strategy, err)
+			}
+		})
+	}
+}
+
+func TestConvertRules_UnknownStrategy(t *testing.T) {
+	_, err := convertRules([]ConversionRule{{Strategy: "Bogus"}})
+	if err == nil {
+		t.Fatalf("expected an error for an unrecognized strategy")
+	}
+}
+
+func TestConvertRules_IndexAndStrategyInErrorMessage(t *testing.T) {
+	rules := []ConversionRule{
+		{Strategy: StrategyFieldRename, FieldRename: &FieldRenameParams{HubPath: "a", SpokePath: "b"}},
+		{Strategy: StrategyDelete}, // missing params, at index 1
+	}
+	_, err := convertRules(rules)
+	if err == nil {
+		t.Fatalf("expected an error")
+	}
+	if !strings.Contains(err.Error(), "rule 1") || !strings.Contains(err.Error(), string(StrategyDelete)) {
+		t.Fatalf("expected the error to identify rule index 1 and strategy Delete, got: %v", err)
+	}
+}
+
+func TestConvertRules_ForEachNesting(t *testing.T) {
+	rule := wellFormedRules()[StrategyForEach]
+	out, err := convertRules([]ConversionRule{rule})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	params, ok := out[0].Params.(engine.ForEachParams)
+	if !ok {
+		t.Fatalf("expected engine.ForEachParams, got %T", out[0].Params)
+	}
+	if len(params.Rules) != 1 || params.Rules[0].Strategy != engine.Strategy(StrategyFieldRename) {
+		t.Fatalf("expected one nested FieldRename rule, got %+v", params.Rules)
+	}
+}
+
+func TestConvertRules_ForEachNestedErrorIsWrapped(t *testing.T) {
+	rule := ConversionRule{
+		Strategy: StrategyForEach,
+		ForEach: &ForEachParams{
+			HubItemsPath: "spec.items", SpokeItemsPath: "spec.items",
+			Rules: []ConversionRule{{Strategy: StrategyFieldRename}}, // missing params
+		},
+	}
+	_, err := convertRules([]ConversionRule{rule})
+	if err == nil {
+		t.Fatalf("expected an error from the nested rule")
+	}
+	if !strings.Contains(err.Error(), "nested rules") {
+		t.Fatalf("expected the error to be wrapped with \"nested rules\", got: %v", err)
+	}
+}
+
+func TestConvertParams_InvalidJSONValue(t *testing.T) {
+	cases := map[string]ConversionRule{
+		"DefaultValue": {Strategy: StrategyDefaultValue, DefaultValue: &DefaultValueParams{Path: "p", ExistsOn: SideHub, Default: rawJSON(`{not json`)}},
+		"Constant":     {Strategy: StrategyConstant, Constant: &ConstantParams{Path: "p", ExistsOn: SideHub, Value: rawJSON(`{not json`)}},
+		"JSONPatchValue": {
+			Strategy:  StrategyJSONPatch,
+			JSONPatch: &JSONPatchParams{HubToSpoke: []JSONPatchOp{{Op: "add", Path: "/p", Value: ptrJSON(rawJSON(`{not json`))}}},
+		},
+		"ScalarToObjectDefaults": {
+			Strategy: StrategyScalarToObject,
+			ScalarToObject: &ScalarToObjectParams{
+				HubPath: "a", SpokePath: "b", Key: "k",
+				DefaultsForOtherKeys: map[string]extv1.JSON{"x": rawJSON(`{not json`)},
+			},
+		},
+	}
+	for name, rule := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := convertRules([]ConversionRule{rule}); err == nil {
+				t.Fatalf("expected an error for malformed JSON in %s", name)
+			}
+		})
+	}
+}
+
+func TestConvertParams_DefaultValueOmittedIsNil(t *testing.T) {
+	// An unset extv1.JSON.Raw (as opposed to an explicit JSON "null") must
+	// convert to a nil Go value, not an error — jsonToAny's empty-Raw guard.
+	rule := ConversionRule{Strategy: StrategyConstant, Constant: &ConstantParams{Path: "p", ExistsOn: SideHub}}
+	out, err := convertRules([]ConversionRule{rule})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	params := out[0].Params.(engine.ConstantParams)
+	if params.Value != nil {
+		t.Fatalf("expected a nil Value for an omitted JSON literal, got %v", params.Value)
+	}
+}
+
+func TestToRuleSets_XRDConversionConfig(t *testing.T) {
+	cfg := &XRDConversionConfig{Spec: XRDConversionConfigSpec{
+		HubVersion: "v2",
+		Spokes: []SpokeVersionRules{
+			{
+				Version: "v1",
+				Rules:   []ConversionRule{{Strategy: StrategyFieldRename, FieldRename: &FieldRenameParams{HubPath: "a", SpokePath: "b"}}},
+			},
+			{
+				Version: "v1beta1",
+				Rules:   []ConversionRule{{Strategy: StrategyDelete, Delete: &DeleteParams{Path: "c", ExistsOn: SideHub}}},
+			},
+		},
+	}}
+
+	ruleSets, err := cfg.ToRuleSets()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(ruleSets) != 2 {
+		t.Fatalf("expected 2 rule sets, got %d", len(ruleSets))
+	}
+	if ruleSets[0].HubVersion != "v2" || ruleSets[0].SpokeVersion != "v1" {
+		t.Fatalf("unexpected first rule set: %+v", ruleSets[0])
+	}
+	if ruleSets[0].UnmappedFieldPolicy != engine.UnmappedFieldPolicy(UnmappedFieldPolicyError) {
+		t.Fatalf("expected the default UnmappedFieldPolicy (Error) when unset, got %q", ruleSets[0].UnmappedFieldPolicy)
+	}
+
+	cfg.Spec.UnmappedFieldPolicy = UnmappedFieldPolicyWarn
+	ruleSets, err = cfg.ToRuleSets()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, rs := range ruleSets {
+		if rs.UnmappedFieldPolicy != engine.UnmappedFieldPolicy(UnmappedFieldPolicyWarn) {
+			t.Fatalf("expected the explicitly set UnmappedFieldPolicy (Warn) to apply to every spoke, got %q for spoke %q", rs.UnmappedFieldPolicy, rs.SpokeVersion)
+		}
+	}
+}
+
+func TestToRuleSets_XRDConversionConfig_PropagatesSpokeError(t *testing.T) {
+	cfg := &XRDConversionConfig{Spec: XRDConversionConfigSpec{
+		HubVersion: "v2",
+		Spokes: []SpokeVersionRules{
+			{Version: "v1", Rules: []ConversionRule{{Strategy: StrategyFieldRename}}}, // missing params
+		},
+	}}
+	_, err := cfg.ToRuleSets()
+	if err == nil {
+		t.Fatalf("expected an error")
+	}
+	if !strings.Contains(err.Error(), `spoke "v1"`) {
+		t.Fatalf("expected the error to name the offending spoke version, got: %v", err)
+	}
+}
+
+func TestToRuleSets_CRDConversionConfig(t *testing.T) {
+	cfg := &CRDConversionConfig{Spec: CRDConversionConfigSpec{
+		HubVersion: "v2",
+		Spokes: []SpokeVersionRules{
+			{Version: "v1", Rules: []ConversionRule{{Strategy: StrategyFieldRename, FieldRename: &FieldRenameParams{HubPath: "a", SpokePath: "b"}}}},
+		},
+	}}
+	ruleSets, err := cfg.ToRuleSets()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(ruleSets) != 1 || ruleSets[0].SpokeVersion != "v1" {
+		t.Fatalf("unexpected rule sets: %+v", ruleSets)
+	}
+}

--- a/api/v1alpha1/xrdconversionconfig_convert_test.go
+++ b/api/v1alpha1/xrdconversionconfig_convert_test.go
@@ -25,8 +25,9 @@ import (
 	"github.com/terasky-oss/declarative-conversion-operator/pkg/engine"
 )
 
-// rawJSON builds an extv1.JSON from a literal JSON snippet, panicking on a
-// malformed literal (a test-authoring bug, not a case under test).
+// rawJSON builds an extv1.JSON from a literal, wrapping the bytes verbatim
+// without validating them — some tests deliberately pass malformed JSON to
+// exercise jsonToAny's error path.
 func rawJSON(literal string) extv1.JSON {
 	return extv1.JSON{Raw: []byte(literal)}
 }
@@ -308,7 +309,7 @@ func TestConvertParams_InvalidJSONValue(t *testing.T) {
 	}
 }
 
-func TestConvertParams_DefaultValueOmittedIsNil(t *testing.T) {
+func TestConvertParams_ConstantOmittedValueIsNil(t *testing.T) {
 	// An unset extv1.JSON.Raw (as opposed to an explicit JSON "null") must
 	// convert to a nil Go value, not an error — jsonToAny's empty-Raw guard.
 	rule := ConversionRule{Strategy: StrategyConstant, Constant: &ConstantParams{Path: "p", ExistsOn: SideHub}}
@@ -316,7 +317,10 @@ func TestConvertParams_DefaultValueOmittedIsNil(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	params := out[0].Params.(engine.ConstantParams)
+	params, ok := out[0].Params.(engine.ConstantParams)
+	if !ok {
+		t.Fatalf("expected engine.ConstantParams, got %T", out[0].Params)
+	}
 	if params.Value != nil {
 		t.Fatalf("expected a nil Value for an omitted JSON literal, got %v", params.Value)
 	}

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -173,6 +173,11 @@ func main() {
 	}
 }
 
+// serviceAccountNamespaceFile is a var (not a const) so tests can point it
+// at a path that's guaranteed not to exist, rather than depending on
+// whether the test happens to be running inside a real Kubernetes pod.
+var serviceAccountNamespaceFile = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+
 // currentNamespace returns the namespace the operator is running in,
 // read from the projected service account token directory Kubernetes
 // mounts into every pod. Falls back to "default" for local/dev runs
@@ -182,7 +187,7 @@ func currentNamespace() string {
 	if ns := os.Getenv("POD_NAMESPACE"); ns != "" {
 		return ns
 	}
-	if data, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
+	if data, err := os.ReadFile(serviceAccountNamespaceFile); err == nil {
 		if ns := string(data); ns != "" {
 			return ns
 		}

--- a/cmd/manager/main_test.go
+++ b/cmd/manager/main_test.go
@@ -21,6 +21,8 @@ limitations under the License.
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -31,11 +33,32 @@ func TestCurrentNamespace_PodNamespaceEnvVar(t *testing.T) {
 	}
 }
 
+func TestCurrentNamespace_ReadsServiceAccountFile(t *testing.T) {
+	t.Setenv("POD_NAMESPACE", "")
+	dir := t.TempDir()
+	path := filepath.Join(dir, "namespace")
+	if err := os.WriteFile(path, []byte("from-file-ns"), 0o600); err != nil {
+		t.Fatalf("writing fixture file: %v", err)
+	}
+	old := serviceAccountNamespaceFile
+	serviceAccountNamespaceFile = path
+	defer func() { serviceAccountNamespaceFile = old }()
+
+	if got := currentNamespace(); got != "from-file-ns" {
+		t.Fatalf("expected the namespace read from the service account file, got %q", got)
+	}
+}
+
 func TestCurrentNamespace_FallsBackToDefault(t *testing.T) {
 	t.Setenv("POD_NAMESPACE", "")
-	// This test's sandbox has no
-	// /var/run/secrets/kubernetes.io/serviceaccount/namespace file, so this
-	// also exercises that read failing and falling through.
+	// Point at a path that's guaranteed not to exist, rather than relying
+	// on this test's sandbox not being a real Kubernetes pod (where the
+	// real service-account file would exist and this would otherwise
+	// return that namespace instead of "default").
+	old := serviceAccountNamespaceFile
+	serviceAccountNamespaceFile = filepath.Join(t.TempDir(), "does-not-exist")
+	defer func() { serviceAccountNamespaceFile = old }()
+
 	if got := currentNamespace(); got != "default" {
 		t.Fatalf("expected the \"default\" fallback outside a cluster, got %q", got)
 	}

--- a/cmd/manager/main_test.go
+++ b/cmd/manager/main_test.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2026 The declarative-conversion-operator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// The rest of main() is manager/webhook wiring that needs a real (or
+// envtest) cluster to exercise meaningfully; that's covered by the e2e
+// suite (hack/e2e-test*.sh) instead. currentNamespace() is the one piece
+// of pure, unit-testable logic in this binary.
+package main
+
+import (
+	"testing"
+)
+
+func TestCurrentNamespace_PodNamespaceEnvVar(t *testing.T) {
+	t.Setenv("POD_NAMESPACE", "custom-ns")
+	if got := currentNamespace(); got != "custom-ns" {
+		t.Fatalf("expected POD_NAMESPACE to take priority, got %q", got)
+	}
+}
+
+func TestCurrentNamespace_FallsBackToDefault(t *testing.T) {
+	t.Setenv("POD_NAMESPACE", "")
+	// This test's sandbox has no
+	// /var/run/secrets/kubernetes.io/serviceaccount/namespace file, so this
+	// also exercises that read failing and falling through.
+	if got := currentNamespace(); got != "default" {
+		t.Fatalf("expected the \"default\" fallback outside a cluster, got %q", got)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect

--- a/internal/controller/conversionwebhookserver_controller_test.go
+++ b/internal/controller/conversionwebhookserver_controller_test.go
@@ -118,11 +118,22 @@ func TestCWSReconcile_HappyPath_CreatesChildResources(t *testing.T) {
 	if !meta.IsStatusConditionTrue(got.Status.Conditions, teraskyv1alpha1.CWSConditionServiceReady) {
 		t.Fatalf("expected ServiceReady=True, got %+v", got.Status.Conditions)
 	}
-	if meta.IsStatusConditionTrue(got.Status.Conditions, teraskyv1alpha1.CWSConditionCertificateReady) {
-		t.Fatalf("expected CertificateReady=False without a real cert-manager")
+	requireConditionFalse(t, got.Status.Conditions, teraskyv1alpha1.CWSConditionCertificateReady, "without a real cert-manager")
+	requireConditionFalse(t, got.Status.Conditions, teraskyv1alpha1.CWSConditionAvailable, "since the fake client never marks the Deployment Available")
+}
+
+// requireConditionFalse fails the test unless conditionType is present with
+// Status == False — unlike a bare !meta.IsStatusConditionTrue check, this
+// also catches the condition being absent or Unknown, either of which would
+// otherwise slip through a merely-not-True assertion.
+func requireConditionFalse(t *testing.T, conditions []metav1.Condition, conditionType, why string) {
+	t.Helper()
+	c := meta.FindStatusCondition(conditions, conditionType)
+	if c == nil {
+		t.Fatalf("expected condition %s to be present and False (%s), but it was absent: %+v", conditionType, why, conditions)
 	}
-	if meta.IsStatusConditionTrue(got.Status.Conditions, teraskyv1alpha1.CWSConditionAvailable) {
-		t.Fatalf("expected Available=False since the fake client never marks the Deployment Available")
+	if c.Status != metav1.ConditionFalse {
+		t.Fatalf("expected condition %s=False (%s), got %s", conditionType, why, c.Status)
 	}
 }
 

--- a/internal/controller/conversionwebhookserver_controller_test.go
+++ b/internal/controller/conversionwebhookserver_controller_test.go
@@ -1,0 +1,384 @@
+/*
+Copyright 2026 The declarative-conversion-operator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	teraskyv1alpha1 "github.com/terasky-oss/declarative-conversion-operator/api/v1alpha1"
+)
+
+func reconcileCWS(t *testing.T, r *ConversionWebhookServerReconciler, name string) (reconcile.Result, error) {
+	t.Helper()
+	return r.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{Name: name}})
+}
+
+func getCWS(t *testing.T, r *ConversionWebhookServerReconciler, name string) *teraskyv1alpha1.ConversionWebhookServer {
+	t.Helper()
+	var s teraskyv1alpha1.ConversionWebhookServer
+	if err := r.Get(context.Background(), types.NamespacedName{Name: name}, &s); err != nil {
+		t.Fatalf("getting ConversionWebhookServer %q: %v", name, err)
+	}
+	return &s
+}
+
+func TestCWSReconcile_HappyPath_CreatesChildResources(t *testing.T) {
+	server := &teraskyv1alpha1.ConversionWebhookServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "srv"},
+		Spec: teraskyv1alpha1.ConversionWebhookServerSpec{
+			Namespace: "operator-ns",
+			Certificate: teraskyv1alpha1.CertificateSpec{
+				IssuerRef: teraskyv1alpha1.CertificateIssuerRef{Name: "ca-issuer"},
+			},
+		},
+	}
+	c := newFakeClient(server).build().Build()
+	r := &ConversionWebhookServerReconciler{Client: c, Scheme: newScheme(), DefaultNamespace: "operator-ns", DefaultImage: "test/image:v1"}
+
+	if _, err := reconcileCWS(t, r, "srv"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := getCWS(t, r, "srv")
+	if !controllerutil.ContainsFinalizer(got, teraskyv1alpha1.ConversionWebhookServerFinalizer) {
+		t.Fatalf("expected the finalizer to be added")
+	}
+
+	var svc corev1.Service
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "srv-webhook-server", Namespace: "operator-ns"}, &svc); err != nil {
+		t.Fatalf("expected a Service to be created: %v", err)
+	}
+	if len(svc.Spec.Ports) != 2 {
+		t.Fatalf("expected 2 service ports (conversion+metrics), got %d", len(svc.Spec.Ports))
+	}
+
+	var dep appsv1.Deployment
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "srv-webhook-server", Namespace: "operator-ns"}, &dep); err != nil {
+		t.Fatalf("expected a Deployment to be created: %v", err)
+	}
+	if len(dep.Spec.Template.Spec.Containers) != 1 || dep.Spec.Template.Spec.Containers[0].Image != "test/image:v1" {
+		t.Fatalf("unexpected deployment containers: %+v", dep.Spec.Template.Spec.Containers)
+	}
+	if dep.Spec.Replicas == nil || *dep.Spec.Replicas != 2 {
+		t.Fatalf("expected the default replica count of 2 when autoscaling is unset, got %v", dep.Spec.Replicas)
+	}
+
+	var cert unstructured.Unstructured
+	cert.SetGroupVersionKind(CertificateGroupVersionKind)
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "srv-webhook-server-cert", Namespace: "operator-ns"}, &cert); err != nil {
+		t.Fatalf("expected a Certificate to be created: %v", err)
+	}
+
+	// No HPA/PDB should exist: neither Autoscaling nor PodDisruptionBudget was set.
+	var hpa autoscalingv2.HorizontalPodAutoscaler
+	err := r.Get(context.Background(), types.NamespacedName{Name: "srv-webhook-server", Namespace: "operator-ns"}, &hpa)
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("expected no HPA to exist, got err=%v", err)
+	}
+	var pdb policyv1.PodDisruptionBudget
+	err = r.Get(context.Background(), types.NamespacedName{Name: "srv-webhook-server", Namespace: "operator-ns"}, &pdb)
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("expected no PDB to exist, got err=%v", err)
+	}
+
+	// updateStatus should reflect reality: Service exists (ServiceReady
+	// True), no cert Secret ever materializes under the fake client
+	// (cert-manager isn't running), so CertificateReady stays False, and
+	// the Deployment fake client never simulates a controller marking it
+	// Available.
+	if !meta.IsStatusConditionTrue(got.Status.Conditions, teraskyv1alpha1.CWSConditionServiceReady) {
+		t.Fatalf("expected ServiceReady=True, got %+v", got.Status.Conditions)
+	}
+	if meta.IsStatusConditionTrue(got.Status.Conditions, teraskyv1alpha1.CWSConditionCertificateReady) {
+		t.Fatalf("expected CertificateReady=False without a real cert-manager")
+	}
+}
+
+func TestCWSReconcile_Autoscaling_CreatesHPA_NoStaticReplicas(t *testing.T) {
+	server := &teraskyv1alpha1.ConversionWebhookServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "srv"},
+		Spec: teraskyv1alpha1.ConversionWebhookServerSpec{
+			Namespace:   "operator-ns",
+			Certificate: teraskyv1alpha1.CertificateSpec{IssuerRef: teraskyv1alpha1.CertificateIssuerRef{Name: "ca-issuer"}},
+			Autoscaling: &teraskyv1alpha1.AutoscalingSpec{MinReplicas: 2, MaxReplicas: 5},
+		},
+	}
+	c := newFakeClient(server).build().Build()
+	r := &ConversionWebhookServerReconciler{Client: c, Scheme: newScheme(), DefaultNamespace: "operator-ns"}
+
+	if _, err := reconcileCWS(t, r, "srv"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var hpa autoscalingv2.HorizontalPodAutoscaler
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "srv-webhook-server", Namespace: "operator-ns"}, &hpa); err != nil {
+		t.Fatalf("expected an HPA to be created: %v", err)
+	}
+	if hpa.Spec.MinReplicas == nil || *hpa.Spec.MinReplicas != 2 || hpa.Spec.MaxReplicas != 5 {
+		t.Fatalf("unexpected HPA spec: %+v", hpa.Spec)
+	}
+}
+
+func TestCWSReconcile_PodDisruptionBudget_Created(t *testing.T) {
+	minAvail := intstr.FromInt32(1)
+	server := &teraskyv1alpha1.ConversionWebhookServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "srv"},
+		Spec: teraskyv1alpha1.ConversionWebhookServerSpec{
+			Namespace:           "operator-ns",
+			Certificate:         teraskyv1alpha1.CertificateSpec{IssuerRef: teraskyv1alpha1.CertificateIssuerRef{Name: "ca-issuer"}},
+			PodDisruptionBudget: &teraskyv1alpha1.PodDisruptionBudgetSpec{MinAvailable: &minAvail},
+		},
+	}
+	c := newFakeClient(server).build().Build()
+	r := &ConversionWebhookServerReconciler{Client: c, Scheme: newScheme(), DefaultNamespace: "operator-ns"}
+
+	if _, err := reconcileCWS(t, r, "srv"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var pdb policyv1.PodDisruptionBudget
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "srv-webhook-server", Namespace: "operator-ns"}, &pdb); err != nil {
+		t.Fatalf("expected a PDB to be created: %v", err)
+	}
+	if pdb.Spec.MinAvailable == nil || pdb.Spec.MinAvailable.IntVal != 1 {
+		t.Fatalf("unexpected PDB spec: %+v", pdb.Spec)
+	}
+}
+
+func TestCWSReconcile_TogglingAutoscalingOff_DeletesExistingHPA(t *testing.T) {
+	server := &teraskyv1alpha1.ConversionWebhookServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "srv"},
+		Spec: teraskyv1alpha1.ConversionWebhookServerSpec{
+			Namespace:   "operator-ns",
+			Certificate: teraskyv1alpha1.CertificateSpec{IssuerRef: teraskyv1alpha1.CertificateIssuerRef{Name: "ca-issuer"}},
+		},
+	}
+	existingHPA := &autoscalingv2.HorizontalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: "srv-webhook-server", Namespace: "operator-ns"}}
+	c := newFakeClient(server, existingHPA).build().Build()
+	r := &ConversionWebhookServerReconciler{Client: c, Scheme: newScheme(), DefaultNamespace: "operator-ns"}
+
+	if _, err := reconcileCWS(t, r, "srv"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var hpa autoscalingv2.HorizontalPodAutoscaler
+	err := r.Get(context.Background(), types.NamespacedName{Name: "srv-webhook-server", Namespace: "operator-ns"}, &hpa)
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("expected the pre-existing HPA to be deleted once Autoscaling is unset, got err=%v", err)
+	}
+}
+
+func TestCWSReconcile_DefaultConflict_SetsCondition(t *testing.T) {
+	other := &teraskyv1alpha1.ConversionWebhookServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "other"},
+		Spec:       teraskyv1alpha1.ConversionWebhookServerSpec{Default: true, Namespace: "operator-ns"},
+	}
+	server := &teraskyv1alpha1.ConversionWebhookServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "srv"},
+		Spec: teraskyv1alpha1.ConversionWebhookServerSpec{
+			Default: true, Namespace: "operator-ns",
+			Certificate: teraskyv1alpha1.CertificateSpec{IssuerRef: teraskyv1alpha1.CertificateIssuerRef{Name: "ca-issuer"}},
+		},
+	}
+	c := newFakeClient(other, server).build().Build()
+	r := &ConversionWebhookServerReconciler{Client: c, Scheme: newScheme(), DefaultNamespace: "operator-ns"}
+
+	if _, err := reconcileCWS(t, r, "srv"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := getCWS(t, r, "srv")
+	if !meta.IsStatusConditionTrue(got.Status.Conditions, teraskyv1alpha1.CWSConditionDefaultConflict) {
+		t.Fatalf("expected DefaultConflict=True when two instances are marked default, got %+v", got.Status.Conditions)
+	}
+}
+
+func TestCWSReconcile_Delete_BlockedByDependentConfigs(t *testing.T) {
+	server := &teraskyv1alpha1.ConversionWebhookServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "srv"},
+		Spec:       teraskyv1alpha1.ConversionWebhookServerSpec{Namespace: "operator-ns"},
+	}
+	controllerutil.AddFinalizer(server, teraskyv1alpha1.ConversionWebhookServerFinalizer)
+	now := metav1.Now()
+	server.DeletionTimestamp = &now
+
+	depCfg := renameRuleXRDConfig("cfg", "xfoos.example.org")
+	depCfg.Spec.WebhookServerRef = &teraskyv1alpha1.WebhookServerRef{Name: "srv"}
+
+	c := newFakeClient(server, depCfg).build().Build()
+	r := &ConversionWebhookServerReconciler{Client: c, Scheme: newScheme(), DefaultNamespace: "operator-ns"}
+
+	res, err := reconcileCWS(t, r, "srv")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.RequeueAfter == 0 {
+		t.Fatalf("expected a requeue while deletion is blocked")
+	}
+	got := getCWS(t, r, "srv")
+	if !controllerutil.ContainsFinalizer(got, teraskyv1alpha1.ConversionWebhookServerFinalizer) {
+		t.Fatalf("finalizer must not be removed while a config still depends on this server")
+	}
+	if !meta.IsStatusConditionTrue(got.Status.Conditions, teraskyv1alpha1.CWSConditionDeletionBlocked) {
+		t.Fatalf("expected DeletionBlocked=True")
+	}
+}
+
+func TestCWSReconcile_Delete_ForceAnnotationBypassesBlock(t *testing.T) {
+	server := &teraskyv1alpha1.ConversionWebhookServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "srv", Annotations: map[string]string{teraskyv1alpha1.AllowForceDeleteAnnotation: "true"}},
+		Spec:       teraskyv1alpha1.ConversionWebhookServerSpec{Namespace: "operator-ns"},
+	}
+	controllerutil.AddFinalizer(server, teraskyv1alpha1.ConversionWebhookServerFinalizer)
+	now := metav1.Now()
+	server.DeletionTimestamp = &now
+
+	depCfg := renameRuleXRDConfig("cfg", "xfoos.example.org")
+	depCfg.Spec.WebhookServerRef = &teraskyv1alpha1.WebhookServerRef{Name: "srv"}
+
+	c := newFakeClient(server, depCfg).build().Build()
+	r := &ConversionWebhookServerReconciler{Client: c, Scheme: newScheme(), DefaultNamespace: "operator-ns"}
+
+	if _, err := reconcileCWS(t, r, "srv"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var got teraskyv1alpha1.ConversionWebhookServer
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "srv"}, &got); err == nil {
+		t.Fatalf("expected the server to be gone once force-deleted, got %+v", got)
+	}
+}
+
+func TestCWSReconcile_Delete_NoDependents_RemovesFinalizer(t *testing.T) {
+	server := &teraskyv1alpha1.ConversionWebhookServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "srv"},
+		Spec:       teraskyv1alpha1.ConversionWebhookServerSpec{Namespace: "operator-ns"},
+	}
+	controllerutil.AddFinalizer(server, teraskyv1alpha1.ConversionWebhookServerFinalizer)
+	now := metav1.Now()
+	server.DeletionTimestamp = &now
+
+	c := newFakeClient(server).build().Build()
+	r := &ConversionWebhookServerReconciler{Client: c, Scheme: newScheme(), DefaultNamespace: "operator-ns"}
+
+	if _, err := reconcileCWS(t, r, "srv"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var got teraskyv1alpha1.ConversionWebhookServer
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "srv"}, &got); err == nil {
+		t.Fatalf("expected the server to be gone once its finalizer is removed, got %+v", got)
+	}
+}
+
+func TestCWSReconcile_NotFound_IsIgnored(t *testing.T) {
+	c := newFakeClient().build().Build()
+	r := &ConversionWebhookServerReconciler{Client: c, Scheme: newScheme(), DefaultNamespace: "operator-ns"}
+	if _, err := reconcileCWS(t, r, "does-not-exist"); err != nil {
+		t.Fatalf("expected a NotFound Get to be swallowed, got %v", err)
+	}
+}
+
+// --- pure helper functions, no client needed ---
+
+func TestDeploymentAvailable(t *testing.T) {
+	dep := &appsv1.Deployment{}
+	if deploymentAvailable(dep) {
+		t.Fatalf("expected false with no conditions")
+	}
+	dep.Status.Conditions = []appsv1.DeploymentCondition{{Type: appsv1.DeploymentAvailable, Status: corev1.ConditionFalse}}
+	if deploymentAvailable(dep) {
+		t.Fatalf("expected false when the Available condition is False")
+	}
+	dep.Status.Conditions[0].Status = corev1.ConditionTrue
+	if !deploymentAvailable(dep) {
+		t.Fatalf("expected true when the Available condition is True")
+	}
+}
+
+func TestAvailableCondition(t *testing.T) {
+	c := availableCondition(true, nil)
+	if c.Status != metav1.ConditionTrue || c.Reason != "DeploymentAvailable" {
+		t.Fatalf("unexpected condition for available=true: %+v", c)
+	}
+	c = availableCondition(false, nil)
+	if c.Status != metav1.ConditionFalse || c.Reason != "DeploymentNotAvailable" {
+		t.Fatalf("unexpected condition for available=false, no error: %+v", c)
+	}
+	c = availableCondition(false, errors.New("boom"))
+	if c.Message == "" || c.Status != metav1.ConditionFalse {
+		t.Fatalf("expected a message surfacing the lookup error: %+v", c)
+	}
+}
+
+func TestCertMessage(t *testing.T) {
+	if got := certMessage(errors.New("boom"), false); got == "" {
+		t.Fatalf("expected a non-empty message on lookup error")
+	}
+	if got := certMessage(nil, true); got == "" {
+		t.Fatalf("expected a non-empty message when ready")
+	}
+	if got := certMessage(nil, false); got == "" {
+		t.Fatalf("expected a non-empty message when not ready")
+	}
+}
+
+func TestBoolStatusAndReasonFor(t *testing.T) {
+	if boolStatus(true) != metav1.ConditionTrue || boolStatus(false) != metav1.ConditionFalse {
+		t.Fatalf("boolStatus mismatch")
+	}
+	if reasonFor(true, "yes", "no") != "yes" || reasonFor(false, "yes", "no") != "no" {
+		t.Fatalf("reasonFor mismatch")
+	}
+}
+
+func TestOrString(t *testing.T) {
+	if orString("", "default") != "default" {
+		t.Fatalf("expected the default when empty")
+	}
+	if orString("set", "default") != "set" {
+		t.Fatalf("expected the explicit value to win")
+	}
+}
+
+func TestPodLabels(t *testing.T) {
+	labels := podLabels("srv")
+	if labels["app.kubernetes.io/instance"] != "srv" {
+		t.Fatalf("unexpected labels: %+v", labels)
+	}
+}
+
+func TestNamingHelpers(t *testing.T) {
+	if cwsDeploymentName("srv") != "srv-webhook-server" {
+		t.Fatalf("unexpected deployment name")
+	}
+	if cwsCertificateSecretName("srv") != "srv-webhook-server-tls" {
+		t.Fatalf("unexpected secret name")
+	}
+}

--- a/internal/controller/conversionwebhookserver_controller_test.go
+++ b/internal/controller/conversionwebhookserver_controller_test.go
@@ -61,7 +61,7 @@ func TestCWSReconcile_HappyPath_CreatesChildResources(t *testing.T) {
 			},
 		},
 	}
-	c := newFakeClient(server).build().Build()
+	c := newFakeClient(server).Build()
 	r := &ConversionWebhookServerReconciler{Client: c, Scheme: newScheme(), DefaultNamespace: "operator-ns", DefaultImage: "test/image:v1"}
 
 	if _, err := reconcileCWS(t, r, "srv"); err != nil {
@@ -121,6 +121,9 @@ func TestCWSReconcile_HappyPath_CreatesChildResources(t *testing.T) {
 	if meta.IsStatusConditionTrue(got.Status.Conditions, teraskyv1alpha1.CWSConditionCertificateReady) {
 		t.Fatalf("expected CertificateReady=False without a real cert-manager")
 	}
+	if meta.IsStatusConditionTrue(got.Status.Conditions, teraskyv1alpha1.CWSConditionAvailable) {
+		t.Fatalf("expected Available=False since the fake client never marks the Deployment Available")
+	}
 }
 
 func TestCWSReconcile_Autoscaling_CreatesHPA_NoStaticReplicas(t *testing.T) {
@@ -132,7 +135,7 @@ func TestCWSReconcile_Autoscaling_CreatesHPA_NoStaticReplicas(t *testing.T) {
 			Autoscaling: &teraskyv1alpha1.AutoscalingSpec{MinReplicas: 2, MaxReplicas: 5},
 		},
 	}
-	c := newFakeClient(server).build().Build()
+	c := newFakeClient(server).Build()
 	r := &ConversionWebhookServerReconciler{Client: c, Scheme: newScheme(), DefaultNamespace: "operator-ns"}
 
 	if _, err := reconcileCWS(t, r, "srv"); err != nil {
@@ -158,7 +161,7 @@ func TestCWSReconcile_PodDisruptionBudget_Created(t *testing.T) {
 			PodDisruptionBudget: &teraskyv1alpha1.PodDisruptionBudgetSpec{MinAvailable: &minAvail},
 		},
 	}
-	c := newFakeClient(server).build().Build()
+	c := newFakeClient(server).Build()
 	r := &ConversionWebhookServerReconciler{Client: c, Scheme: newScheme(), DefaultNamespace: "operator-ns"}
 
 	if _, err := reconcileCWS(t, r, "srv"); err != nil {
@@ -183,7 +186,7 @@ func TestCWSReconcile_TogglingAutoscalingOff_DeletesExistingHPA(t *testing.T) {
 		},
 	}
 	existingHPA := &autoscalingv2.HorizontalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: "srv-webhook-server", Namespace: "operator-ns"}}
-	c := newFakeClient(server, existingHPA).build().Build()
+	c := newFakeClient(server, existingHPA).Build()
 	r := &ConversionWebhookServerReconciler{Client: c, Scheme: newScheme(), DefaultNamespace: "operator-ns"}
 
 	if _, err := reconcileCWS(t, r, "srv"); err != nil {
@@ -209,7 +212,7 @@ func TestCWSReconcile_DefaultConflict_SetsCondition(t *testing.T) {
 			Certificate: teraskyv1alpha1.CertificateSpec{IssuerRef: teraskyv1alpha1.CertificateIssuerRef{Name: "ca-issuer"}},
 		},
 	}
-	c := newFakeClient(other, server).build().Build()
+	c := newFakeClient(other, server).Build()
 	r := &ConversionWebhookServerReconciler{Client: c, Scheme: newScheme(), DefaultNamespace: "operator-ns"}
 
 	if _, err := reconcileCWS(t, r, "srv"); err != nil {
@@ -233,7 +236,7 @@ func TestCWSReconcile_Delete_BlockedByDependentConfigs(t *testing.T) {
 	depCfg := renameRuleXRDConfig("cfg", "xfoos.example.org")
 	depCfg.Spec.WebhookServerRef = &teraskyv1alpha1.WebhookServerRef{Name: "srv"}
 
-	c := newFakeClient(server, depCfg).build().Build()
+	c := newFakeClient(server, depCfg).Build()
 	r := &ConversionWebhookServerReconciler{Client: c, Scheme: newScheme(), DefaultNamespace: "operator-ns"}
 
 	res, err := reconcileCWS(t, r, "srv")
@@ -264,15 +267,16 @@ func TestCWSReconcile_Delete_ForceAnnotationBypassesBlock(t *testing.T) {
 	depCfg := renameRuleXRDConfig("cfg", "xfoos.example.org")
 	depCfg.Spec.WebhookServerRef = &teraskyv1alpha1.WebhookServerRef{Name: "srv"}
 
-	c := newFakeClient(server, depCfg).build().Build()
+	c := newFakeClient(server, depCfg).Build()
 	r := &ConversionWebhookServerReconciler{Client: c, Scheme: newScheme(), DefaultNamespace: "operator-ns"}
 
 	if _, err := reconcileCWS(t, r, "srv"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	var got teraskyv1alpha1.ConversionWebhookServer
-	if err := r.Get(context.Background(), types.NamespacedName{Name: "srv"}, &got); err == nil {
-		t.Fatalf("expected the server to be gone once force-deleted, got %+v", got)
+	err := r.Get(context.Background(), types.NamespacedName{Name: "srv"}, &got)
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("expected the server to be gone once force-deleted, got err=%v obj=%+v", err, got)
 	}
 }
 
@@ -285,20 +289,21 @@ func TestCWSReconcile_Delete_NoDependents_RemovesFinalizer(t *testing.T) {
 	now := metav1.Now()
 	server.DeletionTimestamp = &now
 
-	c := newFakeClient(server).build().Build()
+	c := newFakeClient(server).Build()
 	r := &ConversionWebhookServerReconciler{Client: c, Scheme: newScheme(), DefaultNamespace: "operator-ns"}
 
 	if _, err := reconcileCWS(t, r, "srv"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	var got teraskyv1alpha1.ConversionWebhookServer
-	if err := r.Get(context.Background(), types.NamespacedName{Name: "srv"}, &got); err == nil {
-		t.Fatalf("expected the server to be gone once its finalizer is removed, got %+v", got)
+	err := r.Get(context.Background(), types.NamespacedName{Name: "srv"}, &got)
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("expected the server to be gone once its finalizer is removed, got err=%v obj=%+v", err, got)
 	}
 }
 
 func TestCWSReconcile_NotFound_IsIgnored(t *testing.T) {
-	c := newFakeClient().build().Build()
+	c := newFakeClient().Build()
 	r := &ConversionWebhookServerReconciler{Client: c, Scheme: newScheme(), DefaultNamespace: "operator-ns"}
 	if _, err := reconcileCWS(t, r, "does-not-exist"); err != nil {
 		t.Fatalf("expected a NotFound Get to be swallowed, got %v", err)

--- a/internal/controller/crdconversionconfig_controller_test.go
+++ b/internal/controller/crdconversionconfig_controller_test.go
@@ -49,7 +49,7 @@ func TestCRDReconcile_AddsFinalizerThenApplies(t *testing.T) {
 	cfg := renameRuleCRDConfig("cfg", "foos.example.org")
 	server, secret := readyServer("srv")
 
-	c := newFakeClient(crd, cfg, server, secret).build().Build()
+	c := newFakeClient(crd, cfg, server, secret).Build()
 	r := &CRDConversionConfigReconciler{Client: c, DefaultServerNamespace: "operator-ns"}
 
 	// A single Reconcile call both adds the finalizer and runs
@@ -90,7 +90,7 @@ func TestCRDReconcile_AddsFinalizerThenApplies(t *testing.T) {
 func TestCRDReconcile_TargetCRDMissing_MarksInvalid(t *testing.T) {
 	cfg := renameRuleCRDConfig("cfg", "missing.example.org")
 	controllerutil.AddFinalizer(cfg, teraskyv1alpha1.CRDConversionConfigFinalizer)
-	c := newFakeClient(cfg).build().Build()
+	c := newFakeClient(cfg).Build()
 	r := &CRDConversionConfigReconciler{Client: c, DefaultServerNamespace: "operator-ns"}
 
 	if _, err := reconcileCRD(t, r, "cfg"); err != nil {
@@ -109,7 +109,7 @@ func TestCRDReconcile_CRDNotEstablished_Pending(t *testing.T) {
 	controllerutil.AddFinalizer(cfg, teraskyv1alpha1.CRDConversionConfigFinalizer)
 	server, secret := readyServer("srv")
 
-	c := newFakeClient(crd, cfg, server, secret).build().Build()
+	c := newFakeClient(crd, cfg, server, secret).Build()
 	r := &CRDConversionConfigReconciler{Client: c, DefaultServerNamespace: "operator-ns"}
 
 	res, err := reconcileCRD(t, r, "cfg")
@@ -133,7 +133,7 @@ func TestCRDReconcile_Drift_FailClosed_RevertsAndFails(t *testing.T) {
 	controllerutil.AddFinalizer(cfg, teraskyv1alpha1.CRDConversionConfigFinalizer)
 	server, secret := readyServer("srv")
 
-	c := newFakeClient(crd, cfg, server, secret).build().Build()
+	c := newFakeClient(crd, cfg, server, secret).Build()
 	r := &CRDConversionConfigReconciler{Client: c, DefaultServerNamespace: "operator-ns"}
 
 	live := getCRDConfig(t, r, "cfg")
@@ -167,7 +167,7 @@ func TestCRDReconcile_Delete_BlockedByMultipleServedVersions(t *testing.T) {
 	now := metav1.Now()
 	cfg.DeletionTimestamp = &now
 
-	c := newFakeClient(crd, cfg).build().Build()
+	c := newFakeClient(crd, cfg).Build()
 	r := &CRDConversionConfigReconciler{Client: c, DefaultServerNamespace: "operator-ns"}
 
 	res, err := reconcileCRD(t, r, "cfg")
@@ -195,7 +195,7 @@ func TestCRDReconcile_Delete_UnsafeOverrideRemovesFinalizer(t *testing.T) {
 	now := metav1.Now()
 	cfg.DeletionTimestamp = &now
 
-	c := newFakeClient(crd, cfg).build().Build()
+	c := newFakeClient(crd, cfg).Build()
 	r := &CRDConversionConfigReconciler{Client: c, DefaultServerNamespace: "operator-ns"}
 
 	if _, err := reconcileCRD(t, r, "cfg"); err != nil {
@@ -208,7 +208,7 @@ func TestCRDReconcile_Delete_UnsafeOverrideRemovesFinalizer(t *testing.T) {
 }
 
 func TestCRDReconcile_NotFound_IsIgnored(t *testing.T) {
-	c := newFakeClient().build().Build()
+	c := newFakeClient().Build()
 	r := &CRDConversionConfigReconciler{Client: c, DefaultServerNamespace: "operator-ns"}
 	if _, err := reconcileCRD(t, r, "does-not-exist"); err != nil {
 		t.Fatalf("expected a NotFound Get to be swallowed, got %v", err)

--- a/internal/controller/crdconversionconfig_controller_test.go
+++ b/internal/controller/crdconversionconfig_controller_test.go
@@ -1,0 +1,216 @@
+/*
+Copyright 2026 The declarative-conversion-operator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	teraskyv1alpha1 "github.com/terasky-oss/declarative-conversion-operator/api/v1alpha1"
+)
+
+func reconcileCRD(t *testing.T, r *CRDConversionConfigReconciler, name string) (reconcile.Result, error) {
+	t.Helper()
+	return r.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{Name: name}})
+}
+
+func getCRDConfig(t *testing.T, r *CRDConversionConfigReconciler, name string) *teraskyv1alpha1.CRDConversionConfig {
+	t.Helper()
+	var cfg teraskyv1alpha1.CRDConversionConfig
+	if err := r.Get(context.Background(), types.NamespacedName{Name: name}, &cfg); err != nil {
+		t.Fatalf("getting CRDConversionConfig %q: %v", name, err)
+	}
+	return &cfg
+}
+
+func TestCRDReconcile_AddsFinalizerThenApplies(t *testing.T) {
+	crd := establishedCRD("foos.example.org")
+	cfg := renameRuleCRDConfig("cfg", "foos.example.org")
+	server, secret := readyServer("srv")
+
+	c := newFakeClient(crd, cfg, server, secret).build().Build()
+	r := &CRDConversionConfigReconciler{Client: c, DefaultServerNamespace: "operator-ns"}
+
+	// A single Reconcile call both adds the finalizer and runs
+	// reconcileNormal through to Applied (unlike some controllers, this one
+	// doesn't split that across two events). Deliberately not
+	// double-reconciling here: the fake client's typed Apply for
+	// CustomResourceDefinition doesn't faithfully preserve fields the
+	// applied config doesn't mention (spec.versions gets dropped), which a
+	// real API server's server-side apply would not do — a fake-client
+	// fidelity gap, not a reconciler bug, but one a second Apply in this
+	// test would trip over.
+	if _, err := reconcileCRD(t, r, "cfg"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := getCRDConfig(t, r, "cfg")
+	if !controllerutil.ContainsFinalizer(got, teraskyv1alpha1.CRDConversionConfigFinalizer) {
+		t.Fatalf("expected the finalizer to be added")
+	}
+	if got.Status.Phase != teraskyv1alpha1.PhaseApplied {
+		t.Fatalf("expected phase Applied, got %q (message: %s)", got.Status.Phase, got.Status.Message)
+	}
+	if got.Status.AssignedWebhookServer != "srv" {
+		t.Fatalf("expected assigned server %q, got %q", "srv", got.Status.AssignedWebhookServer)
+	}
+	if !meta.IsStatusConditionTrue(got.Status.Conditions, teraskyv1alpha1.ConditionApplied) {
+		t.Fatalf("expected condition Applied=True")
+	}
+
+	var patched extv1.CustomResourceDefinition
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "foos.example.org"}, &patched); err != nil {
+		t.Fatalf("getting patched CRD: %v", err)
+	}
+	if patched.Spec.Conversion == nil || patched.Spec.Conversion.Strategy != extv1.WebhookConverter {
+		t.Fatalf("expected spec.conversion.strategy=Webhook on the target CRD, got %+v", patched.Spec.Conversion)
+	}
+}
+
+func TestCRDReconcile_TargetCRDMissing_MarksInvalid(t *testing.T) {
+	cfg := renameRuleCRDConfig("cfg", "missing.example.org")
+	controllerutil.AddFinalizer(cfg, teraskyv1alpha1.CRDConversionConfigFinalizer)
+	c := newFakeClient(cfg).build().Build()
+	r := &CRDConversionConfigReconciler{Client: c, DefaultServerNamespace: "operator-ns"}
+
+	if _, err := reconcileCRD(t, r, "cfg"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := getCRDConfig(t, r, "cfg")
+	if got.Status.Phase != teraskyv1alpha1.PhaseInvalid {
+		t.Fatalf("expected phase Invalid, got %q", got.Status.Phase)
+	}
+}
+
+func TestCRDReconcile_CRDNotEstablished_Pending(t *testing.T) {
+	crd := establishedCRD("foos.example.org")
+	crd.Status.Conditions = nil
+	cfg := renameRuleCRDConfig("cfg", "foos.example.org")
+	controllerutil.AddFinalizer(cfg, teraskyv1alpha1.CRDConversionConfigFinalizer)
+	server, secret := readyServer("srv")
+
+	c := newFakeClient(crd, cfg, server, secret).build().Build()
+	r := &CRDConversionConfigReconciler{Client: c, DefaultServerNamespace: "operator-ns"}
+
+	res, err := reconcileCRD(t, r, "cfg")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.RequeueAfter == 0 {
+		t.Fatalf("expected a requeue while waiting on the CRD to become Established")
+	}
+	got := getCRDConfig(t, r, "cfg")
+	if got.Status.Phase != teraskyv1alpha1.PhasePending {
+		t.Fatalf("expected phase Pending, got %q", got.Status.Phase)
+	}
+}
+
+func TestCRDReconcile_Drift_FailClosed_RevertsAndFails(t *testing.T) {
+	crd := establishedCRD("foos.example.org")
+	cfg := renameRuleCRDConfig("cfg", "foos.example.org")
+	cfg.Spec.DriftPolicy = teraskyv1alpha1.DriftPolicyFailClosed
+	cfg.Status.Phase = teraskyv1alpha1.PhaseApplied
+	controllerutil.AddFinalizer(cfg, teraskyv1alpha1.CRDConversionConfigFinalizer)
+	server, secret := readyServer("srv")
+
+	c := newFakeClient(crd, cfg, server, secret).build().Build()
+	r := &CRDConversionConfigReconciler{Client: c, DefaultServerNamespace: "operator-ns"}
+
+	live := getCRDConfig(t, r, "cfg")
+	live.Spec.Spokes[0].Rules[0].FieldRename.HubPath = "spec.doesNotExist"
+	if err := r.Update(context.Background(), live); err != nil {
+		t.Fatalf("updating config: %v", err)
+	}
+
+	if _, err := reconcileCRD(t, r, "cfg"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := getCRDConfig(t, r, "cfg")
+	if got.Status.Phase != teraskyv1alpha1.PhaseFailed {
+		t.Fatalf("expected phase Failed under FailClosed drift, got %q (message: %s)", got.Status.Phase, got.Status.Message)
+	}
+
+	var patched extv1.CustomResourceDefinition
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "foos.example.org"}, &patched); err != nil {
+		t.Fatalf("getting CRD: %v", err)
+	}
+	if patched.Spec.Conversion == nil || patched.Spec.Conversion.Strategy != extv1.NoneConverter {
+		t.Fatalf("expected the CRD to be reverted to strategy=None, got %+v", patched.Spec.Conversion)
+	}
+}
+
+func TestCRDReconcile_Delete_BlockedByMultipleServedVersions(t *testing.T) {
+	crd := establishedCRD("foos.example.org") // v1 and v2, both served
+	cfg := renameRuleCRDConfig("cfg", "foos.example.org")
+	cfg.Status.Phase = teraskyv1alpha1.PhaseApplied
+	controllerutil.AddFinalizer(cfg, teraskyv1alpha1.CRDConversionConfigFinalizer)
+	now := metav1.Now()
+	cfg.DeletionTimestamp = &now
+
+	c := newFakeClient(crd, cfg).build().Build()
+	r := &CRDConversionConfigReconciler{Client: c, DefaultServerNamespace: "operator-ns"}
+
+	res, err := reconcileCRD(t, r, "cfg")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.RequeueAfter == 0 {
+		t.Fatalf("expected a requeue while deletion is blocked")
+	}
+	got := getCRDConfig(t, r, "cfg")
+	if !controllerutil.ContainsFinalizer(got, teraskyv1alpha1.CRDConversionConfigFinalizer) {
+		t.Fatalf("finalizer must not be removed while deletion is blocked")
+	}
+	if !meta.IsStatusConditionTrue(got.Status.Conditions, teraskyv1alpha1.ConditionDeletionBlocked) {
+		t.Fatalf("expected condition DeletionBlocked=True")
+	}
+}
+
+func TestCRDReconcile_Delete_UnsafeOverrideRemovesFinalizer(t *testing.T) {
+	crd := establishedCRD("foos.example.org")
+	cfg := renameRuleCRDConfig("cfg", "foos.example.org")
+	cfg.Status.Phase = teraskyv1alpha1.PhaseApplied
+	cfg.Annotations = map[string]string{teraskyv1alpha1.AllowUnsafeDeleteAnnotation: "true"}
+	controllerutil.AddFinalizer(cfg, teraskyv1alpha1.CRDConversionConfigFinalizer)
+	now := metav1.Now()
+	cfg.DeletionTimestamp = &now
+
+	c := newFakeClient(crd, cfg).build().Build()
+	r := &CRDConversionConfigReconciler{Client: c, DefaultServerNamespace: "operator-ns"}
+
+	if _, err := reconcileCRD(t, r, "cfg"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var got teraskyv1alpha1.CRDConversionConfig
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "cfg"}, &got); err == nil {
+		t.Fatalf("expected the config to be gone once its finalizer is removed, got %+v", got)
+	}
+}
+
+func TestCRDReconcile_NotFound_IsIgnored(t *testing.T) {
+	c := newFakeClient().build().Build()
+	r := &CRDConversionConfigReconciler{Client: c, DefaultServerNamespace: "operator-ns"}
+	if _, err := reconcileCRD(t, r, "does-not-exist"); err != nil {
+		t.Fatalf("expected a NotFound Get to be swallowed, got %v", err)
+	}
+}

--- a/internal/controller/testutil_test.go
+++ b/internal/controller/testutil_test.go
@@ -49,19 +49,11 @@ func must(err error) {
 // enabled for every custom type these reconcilers Status().Patch — without
 // this, the fake client's Update would silently clobber (rather than
 // preserve) status on a spec-only Update, unlike a real API server.
-func newFakeClient(initObjs ...runtime.Object) *fakeClientBuilder {
-	return &fakeClientBuilder{objs: initObjs}
-}
-
-type fakeClientBuilder struct {
-	objs []runtime.Object
-}
-
-func (b *fakeClientBuilder) build() *fake.ClientBuilder {
+func newFakeClient(initObjs ...runtime.Object) *fake.ClientBuilder {
 	return fake.NewClientBuilder().
 		WithScheme(newScheme()).
 		WithStatusSubresource(&teraskyv1alpha1.XRDConversionConfig{}, &teraskyv1alpha1.CRDConversionConfig{}, &teraskyv1alpha1.ConversionWebhookServer{}).
-		WithRuntimeObjects(b.objs...)
+		WithRuntimeObjects(initObjs...)
 }
 
 // establishedXRD returns a minimal, structurally valid unstructured
@@ -203,7 +195,7 @@ func readyServer(name string) (*teraskyv1alpha1.ConversionWebhookServer, *corev1
 		},
 	}
 	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{Name: cwsCertificateSecretName(name), Namespace: "operator-ns"},
+		ObjectMeta: metav1.ObjectMeta{Name: cwsCertificateSecretName(name), Namespace: server.Spec.Namespace},
 		Data:       map[string][]byte{"ca.crt": []byte("fake-ca-bundle")},
 	}
 	return server, secret

--- a/internal/controller/testutil_test.go
+++ b/internal/controller/testutil_test.go
@@ -14,10 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package webhookserver
+package controller
 
 import (
-	"github.com/prometheus/client_golang/prometheus"
+	corev1 "k8s.io/api/core/v1"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -29,13 +29,8 @@ import (
 	"github.com/terasky-oss/declarative-conversion-operator/pkg/xrdadapter"
 )
 
-// newTestRegisterer returns a fresh, isolated Prometheus registry so
-// multiple tests can each construct their own Metrics without colliding
-// on the global default registry's metric names.
-func newTestRegisterer() prometheus.Registerer {
-	return prometheus.NewRegistry()
-}
-
+// newScheme returns a scheme carrying every type these controllers read or
+// write, mirroring cmd/manager's init().
 func newScheme() *runtime.Scheme {
 	s := runtime.NewScheme()
 	must(clientgoscheme.AddToScheme(s))
@@ -50,14 +45,30 @@ func must(err error) {
 	}
 }
 
-func newFakeClient(objs ...runtime.Object) *fake.ClientBuilder {
-	return fake.NewClientBuilder().WithScheme(newScheme()).WithRuntimeObjects(objs...)
+// newFakeClient builds a fake client with status subresource tracking
+// enabled for every custom type these reconcilers Status().Patch — without
+// this, the fake client's Update would silently clobber (rather than
+// preserve) status on a spec-only Update, unlike a real API server.
+func newFakeClient(initObjs ...runtime.Object) *fakeClientBuilder {
+	return &fakeClientBuilder{objs: initObjs}
 }
 
-// establishedXRD mirrors the fixture of the same name in
-// internal/controller and internal/webhook: a hub version (v2) and a spoke
-// version (v1) differing by one renamed field, with a live schema
-// engine.Analyze can validate rules against.
+type fakeClientBuilder struct {
+	objs []runtime.Object
+}
+
+func (b *fakeClientBuilder) build() *fake.ClientBuilder {
+	return fake.NewClientBuilder().
+		WithScheme(newScheme()).
+		WithStatusSubresource(&teraskyv1alpha1.XRDConversionConfig{}, &teraskyv1alpha1.CRDConversionConfig{}, &teraskyv1alpha1.ConversionWebhookServer{}).
+		WithRuntimeObjects(b.objs...)
+}
+
+// establishedXRD returns a minimal, structurally valid unstructured
+// CompositeResourceDefinition with a hub version ("v2") and a spoke version
+// ("v1") differing by exactly one renamed field, and status.conditions
+// marking it Established — enough for xrdadapter.New/Established and
+// engine.Analyze to succeed end to end.
 func establishedXRD(name string) *unstructured.Unstructured {
 	xrd := &unstructured.Unstructured{Object: map[string]any{
 		"metadata": map[string]any{"name": name, "generation": int64(1)},
@@ -96,6 +107,27 @@ func establishedXRD(name string) *unstructured.Unstructured {
 	return xrd
 }
 
+// renameRuleXRDConfig returns an XRDConversionConfig that maps
+// establishedXRD's hub spec.size to spoke v1's spec.storageSize.
+func renameRuleXRDConfig(name, targetXRD string) *teraskyv1alpha1.XRDConversionConfig {
+	return &teraskyv1alpha1.XRDConversionConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: teraskyv1alpha1.XRDConversionConfigSpec{
+			TargetXRD:  teraskyv1alpha1.TargetXRDRef{Name: targetXRD},
+			HubVersion: "v2",
+			Spokes: []teraskyv1alpha1.SpokeVersionRules{{
+				Version: "v1",
+				Rules: []teraskyv1alpha1.ConversionRule{{
+					Strategy:    teraskyv1alpha1.StrategyFieldRename,
+					FieldRename: &teraskyv1alpha1.FieldRenameParams{HubPath: "spec.size", SpokePath: "spec.storageSize"},
+				}},
+			}},
+		},
+	}
+}
+
+// establishedCRD is establishedXRD's typed counterpart for
+// CRDConversionConfigReconciler.
 func establishedCRD(name string) *extv1.CustomResourceDefinition {
 	return &extv1.CustomResourceDefinition{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Generation: 1},
@@ -136,23 +168,6 @@ func establishedCRD(name string) *extv1.CustomResourceDefinition {
 	}
 }
 
-func renameRuleXRDConfig(name, targetXRD string) *teraskyv1alpha1.XRDConversionConfig {
-	return &teraskyv1alpha1.XRDConversionConfig{
-		ObjectMeta: metav1.ObjectMeta{Name: name},
-		Spec: teraskyv1alpha1.XRDConversionConfigSpec{
-			TargetXRD:  teraskyv1alpha1.TargetXRDRef{Name: targetXRD},
-			HubVersion: "v2",
-			Spokes: []teraskyv1alpha1.SpokeVersionRules{{
-				Version: "v1",
-				Rules: []teraskyv1alpha1.ConversionRule{{
-					Strategy:    teraskyv1alpha1.StrategyFieldRename,
-					FieldRename: &teraskyv1alpha1.FieldRenameParams{HubPath: "spec.size", SpokePath: "spec.storageSize"},
-				}},
-			}},
-		},
-	}
-}
-
 func renameRuleCRDConfig(name, targetCRD string) *teraskyv1alpha1.CRDConversionConfig {
 	return &teraskyv1alpha1.CRDConversionConfig{
 		ObjectMeta: metav1.ObjectMeta{Name: name},
@@ -168,4 +183,28 @@ func renameRuleCRDConfig(name, targetCRD string) *teraskyv1alpha1.CRDConversionC
 			}},
 		},
 	}
+}
+
+// readyServer returns a ConversionWebhookServer whose status already
+// reports every isServerReady gate as satisfied, plus a certificate Secret
+// containing a CA bundle — everything XRDConversionConfigReconciler and
+// CRDConversionConfigReconciler need past their health gates.
+func readyServer(name string) (*teraskyv1alpha1.ConversionWebhookServer, *corev1.Secret) {
+	server := &teraskyv1alpha1.ConversionWebhookServer{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec:       teraskyv1alpha1.ConversionWebhookServerSpec{Default: true, Namespace: "operator-ns"},
+		Status: teraskyv1alpha1.ConversionWebhookServerStatus{
+			ReadyReplicas: 2,
+			Conditions: []metav1.Condition{
+				{Type: teraskyv1alpha1.CWSConditionAvailable, Status: metav1.ConditionTrue},
+				{Type: teraskyv1alpha1.CWSConditionCertificateReady, Status: metav1.ConditionTrue},
+				{Type: teraskyv1alpha1.CWSConditionServiceReady, Status: metav1.ConditionTrue},
+			},
+		},
+	}
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: cwsCertificateSecretName(name), Namespace: "operator-ns"},
+		Data:       map[string][]byte{"ca.crt": []byte("fake-ca-bundle")},
+	}
+	return server, secret
 }

--- a/internal/controller/xrdconversionconfig_controller_reconcile_test.go
+++ b/internal/controller/xrdconversionconfig_controller_reconcile_test.go
@@ -1,0 +1,347 @@
+/*
+Copyright 2026 The declarative-conversion-operator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	teraskyv1alpha1 "github.com/terasky-oss/declarative-conversion-operator/api/v1alpha1"
+)
+
+func reconcileXRD(t *testing.T, r *XRDConversionConfigReconciler, name string) (reconcile.Result, error) {
+	t.Helper()
+	return r.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{Name: name}})
+}
+
+func getXRDConfig(t *testing.T, r *XRDConversionConfigReconciler, name string) *teraskyv1alpha1.XRDConversionConfig {
+	t.Helper()
+	var cfg teraskyv1alpha1.XRDConversionConfig
+	if err := r.Get(context.Background(), types.NamespacedName{Name: name}, &cfg); err != nil {
+		t.Fatalf("getting XRDConversionConfig %q: %v", name, err)
+	}
+	return &cfg
+}
+
+func TestXRDReconcile_AddsFinalizerThenApplies(t *testing.T) {
+	xrd := establishedXRD("xfoos.example.org")
+	cfg := renameRuleXRDConfig("cfg", "xfoos.example.org")
+	server, secret := readyServer("srv")
+
+	c := newFakeClient(cfg, server, secret).build().Build()
+	r := &XRDConversionConfigReconciler{Client: c, DefaultServerNamespace: "operator-ns"}
+
+	// First reconcile only adds the finalizer and returns (mirroring the
+	// real controller-runtime flow: it Updates, then the caller's next
+	// event drives reconcileNormal). Feeding it the live XRD only from the
+	// second call on isn't required by the code, but keeping both present
+	// throughout matches how a real cluster would behave and exercises the
+	// same code path.
+	c.Create(context.Background(), xrd)
+	if _, err := reconcileXRD(t, r, "cfg"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := getXRDConfig(t, r, "cfg")
+	if !controllerutil.ContainsFinalizer(got, teraskyv1alpha1.XRDConversionConfigFinalizer) {
+		t.Fatalf("expected the finalizer to be added")
+	}
+
+	// Second reconcile: finalizer already present, so this exercises
+	// reconcileNormal's full happy path straight through to Applied.
+	if _, err := reconcileXRD(t, r, "cfg"); err != nil {
+		t.Fatalf("unexpected error on second reconcile: %v", err)
+	}
+	got = getXRDConfig(t, r, "cfg")
+	if got.Status.Phase != teraskyv1alpha1.PhaseApplied {
+		t.Fatalf("expected phase Applied, got %q (message: %s)", got.Status.Phase, got.Status.Message)
+	}
+	if got.Status.AssignedWebhookServer != "srv" {
+		t.Fatalf("expected assigned server %q, got %q", "srv", got.Status.AssignedWebhookServer)
+	}
+	if !meta.IsStatusConditionTrue(got.Status.Conditions, teraskyv1alpha1.ConditionApplied) {
+		t.Fatalf("expected condition Applied=True, got %+v", got.Status.Conditions)
+	}
+	if got.Status.WebhookPath != "/convert/xfoos.example.org" {
+		t.Fatalf("unexpected webhook path: %q", got.Status.WebhookPath)
+	}
+
+	// The XRD itself should now carry the patched conversion webhook config.
+	var patchedXRD = establishedXRD("xfoos.example.org")
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "xfoos.example.org"}, patchedXRD); err != nil {
+		t.Fatalf("getting patched XRD: %v", err)
+	}
+	strategy, found, _ := stringField(patchedXRD.Object, "spec", "conversion", "strategy")
+	if !found || strategy != "Webhook" {
+		t.Fatalf("expected spec.conversion.strategy=Webhook on the target XRD, found=%v strategy=%q", found, strategy)
+	}
+}
+
+func stringField(obj map[string]any, path ...string) (string, bool, error) {
+	m := obj
+	for i, p := range path {
+		v, ok := m[p]
+		if !ok {
+			return "", false, nil
+		}
+		if i == len(path)-1 {
+			s, ok := v.(string)
+			return s, ok, nil
+		}
+		next, ok := v.(map[string]any)
+		if !ok {
+			return "", false, nil
+		}
+		m = next
+	}
+	return "", false, nil
+}
+
+func TestXRDReconcile_TargetXRDMissing_MarksInvalid(t *testing.T) {
+	cfg := renameRuleXRDConfig("cfg", "missing.example.org")
+	controllerutil.AddFinalizer(cfg, teraskyv1alpha1.XRDConversionConfigFinalizer)
+	c := newFakeClient(cfg).build().Build()
+	r := &XRDConversionConfigReconciler{Client: c, DefaultServerNamespace: "operator-ns"}
+
+	if _, err := reconcileXRD(t, r, "cfg"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := getXRDConfig(t, r, "cfg")
+	if got.Status.Phase != teraskyv1alpha1.PhaseInvalid {
+		t.Fatalf("expected phase Invalid, got %q", got.Status.Phase)
+	}
+	if meta.IsStatusConditionTrue(got.Status.Conditions, teraskyv1alpha1.ConditionValidated) {
+		t.Fatalf("expected condition Validated=False")
+	}
+}
+
+func TestXRDReconcile_XRDNotEstablished_Pending(t *testing.T) {
+	xrd := establishedXRD("xfoos.example.org")
+	xrd.Object["status"] = map[string]any{} // strip the Established condition
+	cfg := renameRuleXRDConfig("cfg", "xfoos.example.org")
+	controllerutil.AddFinalizer(cfg, teraskyv1alpha1.XRDConversionConfigFinalizer)
+	server, secret := readyServer("srv")
+
+	c := newFakeClient(cfg, server, secret).build().Build()
+	c.Create(context.Background(), xrd)
+	r := &XRDConversionConfigReconciler{Client: c, DefaultServerNamespace: "operator-ns"}
+
+	res, err := reconcileXRD(t, r, "cfg")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.RequeueAfter == 0 {
+		t.Fatalf("expected a requeue while waiting on the XRD to become Established")
+	}
+	got := getXRDConfig(t, r, "cfg")
+	if got.Status.Phase != teraskyv1alpha1.PhasePending {
+		t.Fatalf("expected phase Pending, got %q", got.Status.Phase)
+	}
+}
+
+func TestXRDReconcile_ServerNotReady_Pending(t *testing.T) {
+	xrd := establishedXRD("xfoos.example.org")
+	cfg := renameRuleXRDConfig("cfg", "xfoos.example.org")
+	controllerutil.AddFinalizer(cfg, teraskyv1alpha1.XRDConversionConfigFinalizer)
+	server, secret := readyServer("srv")
+	server.Status.ReadyReplicas = 0 // not ready
+
+	c := newFakeClient(cfg, server, secret).build().Build()
+	c.Create(context.Background(), xrd)
+	r := &XRDConversionConfigReconciler{Client: c, DefaultServerNamespace: "operator-ns"}
+
+	res, err := reconcileXRD(t, r, "cfg")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.RequeueAfter == 0 {
+		t.Fatalf("expected a requeue while waiting on the server to become ready")
+	}
+	got := getXRDConfig(t, r, "cfg")
+	if got.Status.Phase != teraskyv1alpha1.PhasePending {
+		t.Fatalf("expected phase Pending, got %q", got.Status.Phase)
+	}
+}
+
+func TestXRDReconcile_NoAssignableServer_Invalid(t *testing.T) {
+	xrd := establishedXRD("xfoos.example.org")
+	cfg := renameRuleXRDConfig("cfg", "xfoos.example.org")
+	controllerutil.AddFinalizer(cfg, teraskyv1alpha1.XRDConversionConfigFinalizer)
+	// No ConversionWebhookServer exists at all.
+	c := newFakeClient(cfg).build().Build()
+	c.Create(context.Background(), xrd)
+	r := &XRDConversionConfigReconciler{Client: c, DefaultServerNamespace: "operator-ns"}
+
+	if _, err := reconcileXRD(t, r, "cfg"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := getXRDConfig(t, r, "cfg")
+	if got.Status.Phase != teraskyv1alpha1.PhaseInvalid {
+		t.Fatalf("expected phase Invalid when no server can be resolved, got %q", got.Status.Phase)
+	}
+}
+
+func TestXRDReconcile_Drift_FailClosed_RevertsAndFails(t *testing.T) {
+	xrd := establishedXRD("xfoos.example.org")
+	cfg := renameRuleXRDConfig("cfg", "xfoos.example.org")
+	cfg.Spec.DriftPolicy = teraskyv1alpha1.DriftPolicyFailClosed
+	cfg.Status.Phase = teraskyv1alpha1.PhaseApplied // simulate a previously-applied config
+	controllerutil.AddFinalizer(cfg, teraskyv1alpha1.XRDConversionConfigFinalizer)
+	server, secret := readyServer("srv")
+
+	c := newFakeClient(cfg, server, secret).build().Build()
+	c.Create(context.Background(), xrd)
+	r := &XRDConversionConfigReconciler{Client: c, DefaultServerNamespace: "operator-ns"}
+
+	// Break the rule so analysis now errors (a rename targeting a
+	// nonexistent hub field), simulating schema drift.
+	live := getXRDConfig(t, r, "cfg")
+	live.Spec.Spokes[0].Rules[0].FieldRename.HubPath = "spec.doesNotExist"
+	if err := r.Update(context.Background(), live); err != nil {
+		t.Fatalf("updating config: %v", err)
+	}
+
+	if _, err := reconcileXRD(t, r, "cfg"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := getXRDConfig(t, r, "cfg")
+	if got.Status.Phase != teraskyv1alpha1.PhaseFailed {
+		t.Fatalf("expected phase Failed under FailClosed drift, got %q (message: %s)", got.Status.Phase, got.Status.Message)
+	}
+
+	var patchedXRD = establishedXRD("xfoos.example.org")
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "xfoos.example.org"}, patchedXRD); err != nil {
+		t.Fatalf("getting XRD: %v", err)
+	}
+	strategy, found, _ := stringField(patchedXRD.Object, "spec", "conversion", "strategy")
+	if !found || strategy != "None" {
+		t.Fatalf("expected the XRD to be reverted to strategy=None, found=%v strategy=%q", found, strategy)
+	}
+}
+
+func TestXRDReconcile_Drift_KeepServingStale(t *testing.T) {
+	xrd := establishedXRD("xfoos.example.org")
+	cfg := renameRuleXRDConfig("cfg", "xfoos.example.org")
+	cfg.Spec.DriftPolicy = teraskyv1alpha1.DriftPolicyKeepServingStale
+	cfg.Status.Phase = teraskyv1alpha1.PhaseApplied
+	controllerutil.AddFinalizer(cfg, teraskyv1alpha1.XRDConversionConfigFinalizer)
+	server, secret := readyServer("srv")
+
+	c := newFakeClient(cfg, server, secret).build().Build()
+	c.Create(context.Background(), xrd)
+	r := &XRDConversionConfigReconciler{Client: c, DefaultServerNamespace: "operator-ns"}
+
+	live := getXRDConfig(t, r, "cfg")
+	live.Spec.Spokes[0].Rules[0].FieldRename.HubPath = "spec.doesNotExist"
+	if err := r.Update(context.Background(), live); err != nil {
+		t.Fatalf("updating config: %v", err)
+	}
+
+	if _, err := reconcileXRD(t, r, "cfg"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := getXRDConfig(t, r, "cfg")
+	if got.Status.Phase != teraskyv1alpha1.PhaseStale {
+		t.Fatalf("expected phase Stale under KeepServingStale drift, got %q", got.Status.Phase)
+	}
+}
+
+func TestXRDReconcile_Delete_BlockedByMultipleServedVersions(t *testing.T) {
+	xrd := establishedXRD("xfoos.example.org") // v1 and v2, both served
+	cfg := renameRuleXRDConfig("cfg", "xfoos.example.org")
+	cfg.Status.Phase = teraskyv1alpha1.PhaseApplied
+	controllerutil.AddFinalizer(cfg, teraskyv1alpha1.XRDConversionConfigFinalizer)
+	now := metav1.Now()
+	cfg.DeletionTimestamp = &now
+
+	c := newFakeClient(cfg).build().Build()
+	c.Create(context.Background(), xrd)
+	r := &XRDConversionConfigReconciler{Client: c, DefaultServerNamespace: "operator-ns"}
+
+	res, err := reconcileXRD(t, r, "cfg")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.RequeueAfter == 0 {
+		t.Fatalf("expected a requeue while deletion is blocked")
+	}
+	got := getXRDConfig(t, r, "cfg")
+	if !controllerutil.ContainsFinalizer(got, teraskyv1alpha1.XRDConversionConfigFinalizer) {
+		t.Fatalf("finalizer must not be removed while deletion is blocked")
+	}
+	if !meta.IsStatusConditionTrue(got.Status.Conditions, teraskyv1alpha1.ConditionDeletionBlocked) {
+		t.Fatalf("expected condition DeletionBlocked=True")
+	}
+}
+
+func TestXRDReconcile_Delete_UnsafeOverrideRemovesFinalizer(t *testing.T) {
+	xrd := establishedXRD("xfoos.example.org")
+	cfg := renameRuleXRDConfig("cfg", "xfoos.example.org")
+	cfg.Status.Phase = teraskyv1alpha1.PhaseApplied
+	cfg.Annotations = map[string]string{teraskyv1alpha1.AllowUnsafeDeleteAnnotation: "true"}
+	controllerutil.AddFinalizer(cfg, teraskyv1alpha1.XRDConversionConfigFinalizer)
+	now := metav1.Now()
+	cfg.DeletionTimestamp = &now
+
+	c := newFakeClient(cfg).build().Build()
+	c.Create(context.Background(), xrd)
+	r := &XRDConversionConfigReconciler{Client: c, DefaultServerNamespace: "operator-ns"}
+
+	if _, err := reconcileXRD(t, r, "cfg"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var got teraskyv1alpha1.XRDConversionConfig
+	err := r.Get(context.Background(), types.NamespacedName{Name: "cfg"}, &got)
+	if err == nil {
+		t.Fatalf("expected the config to be gone once the fake client's finalizer-driven deletion completes, got %+v", got)
+	}
+}
+
+func TestXRDReconcile_Delete_NeverAppliedSkipsRevert(t *testing.T) {
+	cfg := renameRuleXRDConfig("cfg", "xfoos.example.org")
+	// Never applied: Phase is its zero value, not Applied/Stale.
+	controllerutil.AddFinalizer(cfg, teraskyv1alpha1.XRDConversionConfigFinalizer)
+	now := metav1.Now()
+	cfg.DeletionTimestamp = &now
+
+	c := newFakeClient(cfg).build().Build()
+	r := &XRDConversionConfigReconciler{Client: c, DefaultServerNamespace: "operator-ns"}
+
+	if _, err := reconcileXRD(t, r, "cfg"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var got teraskyv1alpha1.XRDConversionConfig
+	err := r.Get(context.Background(), types.NamespacedName{Name: "cfg"}, &got)
+	if err == nil {
+		t.Fatalf("expected the never-applied config to be removed immediately without touching any XRD")
+	}
+}
+
+func TestXRDReconcile_NotFound_IsIgnored(t *testing.T) {
+	c := newFakeClient().build().Build()
+	r := &XRDConversionConfigReconciler{Client: c, DefaultServerNamespace: "operator-ns"}
+	if _, err := reconcileXRD(t, r, "does-not-exist"); err != nil {
+		t.Fatalf("expected a NotFound Get to be swallowed, got %v", err)
+	}
+}

--- a/internal/controller/xrdconversionconfig_controller_reconcile_test.go
+++ b/internal/controller/xrdconversionconfig_controller_reconcile_test.go
@@ -57,7 +57,9 @@ func TestXRDReconcile_AddsFinalizerThenApplies(t *testing.T) {
 	// second call on isn't required by the code, but keeping both present
 	// throughout matches how a real cluster would behave and exercises the
 	// same code path.
-	c.Create(context.Background(), xrd)
+	if err := c.Create(context.Background(), xrd); err != nil {
+		t.Fatalf("creating XRD fixture: %v", err)
+	}
 	if _, err := reconcileXRD(t, r, "cfg"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -143,7 +145,9 @@ func TestXRDReconcile_XRDNotEstablished_Pending(t *testing.T) {
 	server, secret := readyServer("srv")
 
 	c := newFakeClient(cfg, server, secret).build().Build()
-	c.Create(context.Background(), xrd)
+	if err := c.Create(context.Background(), xrd); err != nil {
+		t.Fatalf("creating XRD fixture: %v", err)
+	}
 	r := &XRDConversionConfigReconciler{Client: c, DefaultServerNamespace: "operator-ns"}
 
 	res, err := reconcileXRD(t, r, "cfg")
@@ -167,7 +171,9 @@ func TestXRDReconcile_ServerNotReady_Pending(t *testing.T) {
 	server.Status.ReadyReplicas = 0 // not ready
 
 	c := newFakeClient(cfg, server, secret).build().Build()
-	c.Create(context.Background(), xrd)
+	if err := c.Create(context.Background(), xrd); err != nil {
+		t.Fatalf("creating XRD fixture: %v", err)
+	}
 	r := &XRDConversionConfigReconciler{Client: c, DefaultServerNamespace: "operator-ns"}
 
 	res, err := reconcileXRD(t, r, "cfg")
@@ -189,7 +195,9 @@ func TestXRDReconcile_NoAssignableServer_Invalid(t *testing.T) {
 	controllerutil.AddFinalizer(cfg, teraskyv1alpha1.XRDConversionConfigFinalizer)
 	// No ConversionWebhookServer exists at all.
 	c := newFakeClient(cfg).build().Build()
-	c.Create(context.Background(), xrd)
+	if err := c.Create(context.Background(), xrd); err != nil {
+		t.Fatalf("creating XRD fixture: %v", err)
+	}
 	r := &XRDConversionConfigReconciler{Client: c, DefaultServerNamespace: "operator-ns"}
 
 	if _, err := reconcileXRD(t, r, "cfg"); err != nil {
@@ -210,7 +218,9 @@ func TestXRDReconcile_Drift_FailClosed_RevertsAndFails(t *testing.T) {
 	server, secret := readyServer("srv")
 
 	c := newFakeClient(cfg, server, secret).build().Build()
-	c.Create(context.Background(), xrd)
+	if err := c.Create(context.Background(), xrd); err != nil {
+		t.Fatalf("creating XRD fixture: %v", err)
+	}
 	r := &XRDConversionConfigReconciler{Client: c, DefaultServerNamespace: "operator-ns"}
 
 	// Break the rule so analysis now errors (a rename targeting a
@@ -248,7 +258,9 @@ func TestXRDReconcile_Drift_KeepServingStale(t *testing.T) {
 	server, secret := readyServer("srv")
 
 	c := newFakeClient(cfg, server, secret).build().Build()
-	c.Create(context.Background(), xrd)
+	if err := c.Create(context.Background(), xrd); err != nil {
+		t.Fatalf("creating XRD fixture: %v", err)
+	}
 	r := &XRDConversionConfigReconciler{Client: c, DefaultServerNamespace: "operator-ns"}
 
 	live := getXRDConfig(t, r, "cfg")
@@ -275,7 +287,9 @@ func TestXRDReconcile_Delete_BlockedByMultipleServedVersions(t *testing.T) {
 	cfg.DeletionTimestamp = &now
 
 	c := newFakeClient(cfg).build().Build()
-	c.Create(context.Background(), xrd)
+	if err := c.Create(context.Background(), xrd); err != nil {
+		t.Fatalf("creating XRD fixture: %v", err)
+	}
 	r := &XRDConversionConfigReconciler{Client: c, DefaultServerNamespace: "operator-ns"}
 
 	res, err := reconcileXRD(t, r, "cfg")
@@ -304,7 +318,9 @@ func TestXRDReconcile_Delete_UnsafeOverrideRemovesFinalizer(t *testing.T) {
 	cfg.DeletionTimestamp = &now
 
 	c := newFakeClient(cfg).build().Build()
-	c.Create(context.Background(), xrd)
+	if err := c.Create(context.Background(), xrd); err != nil {
+		t.Fatalf("creating XRD fixture: %v", err)
+	}
 	r := &XRDConversionConfigReconciler{Client: c, DefaultServerNamespace: "operator-ns"}
 
 	if _, err := reconcileXRD(t, r, "cfg"); err != nil {

--- a/internal/controller/xrdconversionconfig_controller_reconcile_test.go
+++ b/internal/controller/xrdconversionconfig_controller_reconcile_test.go
@@ -22,11 +22,13 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	teraskyv1alpha1 "github.com/terasky-oss/declarative-conversion-operator/api/v1alpha1"
+	"github.com/terasky-oss/declarative-conversion-operator/pkg/xrdadapter"
 )
 
 func reconcileXRD(t *testing.T, r *XRDConversionConfigReconciler, name string) (reconcile.Result, error) {
@@ -48,15 +50,9 @@ func TestXRDReconcile_AddsFinalizerThenApplies(t *testing.T) {
 	cfg := renameRuleXRDConfig("cfg", "xfoos.example.org")
 	server, secret := readyServer("srv")
 
-	c := newFakeClient(cfg, server, secret).build().Build()
+	c := newFakeClient(cfg, server, secret).Build()
 	r := &XRDConversionConfigReconciler{Client: c, DefaultServerNamespace: "operator-ns"}
 
-	// First reconcile only adds the finalizer and returns (mirroring the
-	// real controller-runtime flow: it Updates, then the caller's next
-	// event drives reconcileNormal). Feeding it the live XRD only from the
-	// second call on isn't required by the code, but keeping both present
-	// throughout matches how a real cluster would behave and exercises the
-	// same code path.
 	if err := c.Create(context.Background(), xrd); err != nil {
 		t.Fatalf("creating XRD fixture: %v", err)
 	}
@@ -89,40 +85,41 @@ func TestXRDReconcile_AddsFinalizerThenApplies(t *testing.T) {
 	}
 
 	// The XRD itself should now carry the patched conversion webhook config.
-	var patchedXRD = establishedXRD("xfoos.example.org")
+	patchedXRD := &unstructured.Unstructured{}
+	patchedXRD.SetGroupVersionKind(xrdadapter.GroupVersionKind)
 	if err := r.Get(context.Background(), types.NamespacedName{Name: "xfoos.example.org"}, patchedXRD); err != nil {
 		t.Fatalf("getting patched XRD: %v", err)
 	}
-	strategy, found, _ := stringField(patchedXRD.Object, "spec", "conversion", "strategy")
+	strategy, found := stringField(patchedXRD.Object, "spec", "conversion", "strategy")
 	if !found || strategy != "Webhook" {
 		t.Fatalf("expected spec.conversion.strategy=Webhook on the target XRD, found=%v strategy=%q", found, strategy)
 	}
 }
 
-func stringField(obj map[string]any, path ...string) (string, bool, error) {
+func stringField(obj map[string]any, path ...string) (string, bool) {
 	m := obj
 	for i, p := range path {
 		v, ok := m[p]
 		if !ok {
-			return "", false, nil
+			return "", false
 		}
 		if i == len(path)-1 {
 			s, ok := v.(string)
-			return s, ok, nil
+			return s, ok
 		}
 		next, ok := v.(map[string]any)
 		if !ok {
-			return "", false, nil
+			return "", false
 		}
 		m = next
 	}
-	return "", false, nil
+	return "", false
 }
 
 func TestXRDReconcile_TargetXRDMissing_MarksInvalid(t *testing.T) {
 	cfg := renameRuleXRDConfig("cfg", "missing.example.org")
 	controllerutil.AddFinalizer(cfg, teraskyv1alpha1.XRDConversionConfigFinalizer)
-	c := newFakeClient(cfg).build().Build()
+	c := newFakeClient(cfg).Build()
 	r := &XRDConversionConfigReconciler{Client: c, DefaultServerNamespace: "operator-ns"}
 
 	if _, err := reconcileXRD(t, r, "cfg"); err != nil {
@@ -144,7 +141,7 @@ func TestXRDReconcile_XRDNotEstablished_Pending(t *testing.T) {
 	controllerutil.AddFinalizer(cfg, teraskyv1alpha1.XRDConversionConfigFinalizer)
 	server, secret := readyServer("srv")
 
-	c := newFakeClient(cfg, server, secret).build().Build()
+	c := newFakeClient(cfg, server, secret).Build()
 	if err := c.Create(context.Background(), xrd); err != nil {
 		t.Fatalf("creating XRD fixture: %v", err)
 	}
@@ -170,7 +167,7 @@ func TestXRDReconcile_ServerNotReady_Pending(t *testing.T) {
 	server, secret := readyServer("srv")
 	server.Status.ReadyReplicas = 0 // not ready
 
-	c := newFakeClient(cfg, server, secret).build().Build()
+	c := newFakeClient(cfg, server, secret).Build()
 	if err := c.Create(context.Background(), xrd); err != nil {
 		t.Fatalf("creating XRD fixture: %v", err)
 	}
@@ -194,7 +191,7 @@ func TestXRDReconcile_NoAssignableServer_Invalid(t *testing.T) {
 	cfg := renameRuleXRDConfig("cfg", "xfoos.example.org")
 	controllerutil.AddFinalizer(cfg, teraskyv1alpha1.XRDConversionConfigFinalizer)
 	// No ConversionWebhookServer exists at all.
-	c := newFakeClient(cfg).build().Build()
+	c := newFakeClient(cfg).Build()
 	if err := c.Create(context.Background(), xrd); err != nil {
 		t.Fatalf("creating XRD fixture: %v", err)
 	}
@@ -217,7 +214,7 @@ func TestXRDReconcile_Drift_FailClosed_RevertsAndFails(t *testing.T) {
 	controllerutil.AddFinalizer(cfg, teraskyv1alpha1.XRDConversionConfigFinalizer)
 	server, secret := readyServer("srv")
 
-	c := newFakeClient(cfg, server, secret).build().Build()
+	c := newFakeClient(cfg, server, secret).Build()
 	if err := c.Create(context.Background(), xrd); err != nil {
 		t.Fatalf("creating XRD fixture: %v", err)
 	}
@@ -239,11 +236,12 @@ func TestXRDReconcile_Drift_FailClosed_RevertsAndFails(t *testing.T) {
 		t.Fatalf("expected phase Failed under FailClosed drift, got %q (message: %s)", got.Status.Phase, got.Status.Message)
 	}
 
-	var patchedXRD = establishedXRD("xfoos.example.org")
+	patchedXRD := &unstructured.Unstructured{}
+	patchedXRD.SetGroupVersionKind(xrdadapter.GroupVersionKind)
 	if err := r.Get(context.Background(), types.NamespacedName{Name: "xfoos.example.org"}, patchedXRD); err != nil {
 		t.Fatalf("getting XRD: %v", err)
 	}
-	strategy, found, _ := stringField(patchedXRD.Object, "spec", "conversion", "strategy")
+	strategy, found := stringField(patchedXRD.Object, "spec", "conversion", "strategy")
 	if !found || strategy != "None" {
 		t.Fatalf("expected the XRD to be reverted to strategy=None, found=%v strategy=%q", found, strategy)
 	}
@@ -257,7 +255,7 @@ func TestXRDReconcile_Drift_KeepServingStale(t *testing.T) {
 	controllerutil.AddFinalizer(cfg, teraskyv1alpha1.XRDConversionConfigFinalizer)
 	server, secret := readyServer("srv")
 
-	c := newFakeClient(cfg, server, secret).build().Build()
+	c := newFakeClient(cfg, server, secret).Build()
 	if err := c.Create(context.Background(), xrd); err != nil {
 		t.Fatalf("creating XRD fixture: %v", err)
 	}
@@ -286,7 +284,7 @@ func TestXRDReconcile_Delete_BlockedByMultipleServedVersions(t *testing.T) {
 	now := metav1.Now()
 	cfg.DeletionTimestamp = &now
 
-	c := newFakeClient(cfg).build().Build()
+	c := newFakeClient(cfg).Build()
 	if err := c.Create(context.Background(), xrd); err != nil {
 		t.Fatalf("creating XRD fixture: %v", err)
 	}
@@ -317,7 +315,7 @@ func TestXRDReconcile_Delete_UnsafeOverrideRemovesFinalizer(t *testing.T) {
 	now := metav1.Now()
 	cfg.DeletionTimestamp = &now
 
-	c := newFakeClient(cfg).build().Build()
+	c := newFakeClient(cfg).Build()
 	if err := c.Create(context.Background(), xrd); err != nil {
 		t.Fatalf("creating XRD fixture: %v", err)
 	}
@@ -341,7 +339,7 @@ func TestXRDReconcile_Delete_NeverAppliedSkipsRevert(t *testing.T) {
 	now := metav1.Now()
 	cfg.DeletionTimestamp = &now
 
-	c := newFakeClient(cfg).build().Build()
+	c := newFakeClient(cfg).Build()
 	r := &XRDConversionConfigReconciler{Client: c, DefaultServerNamespace: "operator-ns"}
 
 	if _, err := reconcileXRD(t, r, "cfg"); err != nil {
@@ -355,7 +353,7 @@ func TestXRDReconcile_Delete_NeverAppliedSkipsRevert(t *testing.T) {
 }
 
 func TestXRDReconcile_NotFound_IsIgnored(t *testing.T) {
-	c := newFakeClient().build().Build()
+	c := newFakeClient().Build()
 	r := &XRDConversionConfigReconciler{Client: c, DefaultServerNamespace: "operator-ns"}
 	if _, err := reconcileXRD(t, r, "does-not-exist"); err != nil {
 		t.Fatalf("expected a NotFound Get to be swallowed, got %v", err)

--- a/internal/webhook/conversionwebhookserver_webhook_test.go
+++ b/internal/webhook/conversionwebhookserver_webhook_test.go
@@ -1,0 +1,136 @@
+/*
+Copyright 2026 The declarative-conversion-operator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	teraskyv1alpha1 "github.com/terasky-oss/declarative-conversion-operator/api/v1alpha1"
+)
+
+func TestConversionWebhookServerValidator_CheckDefault_NoConflictWhenNotDefault(t *testing.T) {
+	c := newFakeClient().Build()
+	v := &ConversionWebhookServerValidator{Client: c}
+	server := &teraskyv1alpha1.ConversionWebhookServer{ObjectMeta: metav1.ObjectMeta{Name: "srv"}}
+	if _, err := v.ValidateCreate(context.Background(), server); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestConversionWebhookServerValidator_CheckDefault_FirstDefaultAllowed(t *testing.T) {
+	c := newFakeClient().Build()
+	v := &ConversionWebhookServerValidator{Client: c}
+	server := &teraskyv1alpha1.ConversionWebhookServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "srv"},
+		Spec:       teraskyv1alpha1.ConversionWebhookServerSpec{Default: true},
+	}
+	if _, err := v.ValidateCreate(context.Background(), server); err != nil {
+		t.Fatalf("unexpected error for the first default instance: %v", err)
+	}
+}
+
+func TestConversionWebhookServerValidator_CheckDefault_RejectsSecondDefault(t *testing.T) {
+	existing := &teraskyv1alpha1.ConversionWebhookServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "existing"},
+		Spec:       teraskyv1alpha1.ConversionWebhookServerSpec{Default: true},
+	}
+	c := newFakeClient(existing).Build()
+	v := &ConversionWebhookServerValidator{Client: c}
+	server := &teraskyv1alpha1.ConversionWebhookServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "srv"},
+		Spec:       teraskyv1alpha1.ConversionWebhookServerSpec{Default: true},
+	}
+	if _, err := v.ValidateCreate(context.Background(), server); err == nil {
+		t.Fatalf("expected an error when a second instance is marked default")
+	}
+	if _, err := v.ValidateUpdate(context.Background(), server, server); err == nil {
+		t.Fatalf("expected ValidateUpdate to enforce the same rule")
+	}
+}
+
+func TestConversionWebhookServerValidator_CheckDefault_UpdatingSelfIsNotAConflict(t *testing.T) {
+	server := &teraskyv1alpha1.ConversionWebhookServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "srv"},
+		Spec:       teraskyv1alpha1.ConversionWebhookServerSpec{Default: true},
+	}
+	c := newFakeClient(server).Build()
+	v := &ConversionWebhookServerValidator{Client: c}
+	if _, err := v.ValidateUpdate(context.Background(), server, server); err != nil {
+		t.Fatalf("unexpected error: a server must not conflict with itself: %v", err)
+	}
+}
+
+func TestConversionWebhookServerValidator_ValidateDelete_NoDependents(t *testing.T) {
+	server := &teraskyv1alpha1.ConversionWebhookServer{ObjectMeta: metav1.ObjectMeta{Name: "srv"}}
+	c := newFakeClient(server).Build()
+	v := &ConversionWebhookServerValidator{Client: c}
+	if _, err := v.ValidateDelete(context.Background(), server); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestConversionWebhookServerValidator_ValidateDelete_BlockedByXRDConfig(t *testing.T) {
+	server := &teraskyv1alpha1.ConversionWebhookServer{ObjectMeta: metav1.ObjectMeta{Name: "srv"}}
+	cfg := renameRuleXRDConfig("cfg", "xfoos.example.org")
+	cfg.Spec.WebhookServerRef = &teraskyv1alpha1.WebhookServerRef{Name: "srv"}
+	c := newFakeClient(server, cfg).Build()
+	v := &ConversionWebhookServerValidator{Client: c}
+	if _, err := v.ValidateDelete(context.Background(), server); err == nil {
+		t.Fatalf("expected deletion to be blocked by a dependent XRDConversionConfig")
+	}
+}
+
+func TestConversionWebhookServerValidator_ValidateDelete_BlockedByCRDConfig(t *testing.T) {
+	server := &teraskyv1alpha1.ConversionWebhookServer{ObjectMeta: metav1.ObjectMeta{Name: "srv"}}
+	cfg := renameRuleCRDConfig("cfg", "foos.example.org")
+	cfg.Spec.WebhookServerRef = &teraskyv1alpha1.WebhookServerRef{Name: "srv"}
+	c := newFakeClient(server, cfg).Build()
+	v := &ConversionWebhookServerValidator{Client: c}
+	if _, err := v.ValidateDelete(context.Background(), server); err == nil {
+		t.Fatalf("expected deletion to be blocked by a dependent CRDConversionConfig")
+	}
+}
+
+func TestConversionWebhookServerValidator_ValidateDelete_DefaultInstanceBlockedByImplicitDependents(t *testing.T) {
+	server := &teraskyv1alpha1.ConversionWebhookServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "srv"},
+		Spec:       teraskyv1alpha1.ConversionWebhookServerSpec{Default: true},
+	}
+	cfg := renameRuleXRDConfig("cfg", "xfoos.example.org") // no explicit webhookServerRef: falls back to default
+	c := newFakeClient(server, cfg).Build()
+	v := &ConversionWebhookServerValidator{Client: c}
+	_, err := v.ValidateDelete(context.Background(), server)
+	if err == nil {
+		t.Fatalf("expected deletion of the default instance to be blocked by an implicitly-assigned config")
+	}
+}
+
+func TestConversionWebhookServerValidator_ValidateDelete_ForceAnnotationBypasses(t *testing.T) {
+	server := &teraskyv1alpha1.ConversionWebhookServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "srv", Annotations: map[string]string{teraskyv1alpha1.AllowForceDeleteAnnotation: "true"}},
+	}
+	cfg := renameRuleXRDConfig("cfg", "xfoos.example.org")
+	cfg.Spec.WebhookServerRef = &teraskyv1alpha1.WebhookServerRef{Name: "srv"}
+	c := newFakeClient(server, cfg).Build()
+	v := &ConversionWebhookServerValidator{Client: c}
+	if _, err := v.ValidateDelete(context.Background(), server); err != nil {
+		t.Fatalf("expected the force-delete annotation to bypass the block, got: %v", err)
+	}
+}

--- a/internal/webhook/crdconversionconfig_webhook_validate_test.go
+++ b/internal/webhook/crdconversionconfig_webhook_validate_test.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2026 The declarative-conversion-operator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	teraskyv1alpha1 "github.com/terasky-oss/declarative-conversion-operator/api/v1alpha1"
+)
+
+func TestCRDConversionConfigValidator_Disabled_Rejected(t *testing.T) {
+	c := newFakeClient().Build()
+	v := &CRDConversionConfigValidator{Client: c, Enabled: false}
+	cfg := renameRuleCRDConfig("cfg", "foos.example.org")
+	if _, err := v.ValidateCreate(context.Background(), cfg); err == nil {
+		t.Fatalf("expected an error when native CRD support is disabled")
+	}
+}
+
+func TestCRDConversionConfigValidator_DuplicateTarget_Rejected(t *testing.T) {
+	existing := renameRuleCRDConfig("existing", "foos.example.org")
+	c := newFakeClient(existing).Build()
+	v := &CRDConversionConfigValidator{Client: c, Enabled: true}
+	cfg := renameRuleCRDConfig("cfg", "foos.example.org")
+	if _, err := v.ValidateCreate(context.Background(), cfg); err == nil {
+		t.Fatalf("expected an error: only one config per CRD is supported")
+	}
+}
+
+func TestCRDConversionConfigValidator_TargetMissing_WarnsAndSkipsLiveValidation(t *testing.T) {
+	c := newFakeClient().Build()
+	v := &CRDConversionConfigValidator{Client: c, Enabled: true}
+	cfg := renameRuleCRDConfig("cfg", "missing.example.org")
+	warnings, err := v.ValidateCreate(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("unexpected error when the target CRD doesn't exist yet: %v", err)
+	}
+	if len(warnings) == 0 {
+		t.Fatalf("expected a warning about the missing target CRD")
+	}
+}
+
+func TestCRDConversionConfigValidator_WebhookServerRefMissing_Warns(t *testing.T) {
+	crd := establishedCRD("foos.example.org")
+	c := newFakeClient(crd).Build()
+	v := &CRDConversionConfigValidator{Client: c, Enabled: true}
+	cfg := renameRuleCRDConfig("cfg", "foos.example.org")
+	cfg.Spec.WebhookServerRef = &teraskyv1alpha1.WebhookServerRef{Name: "does-not-exist"}
+	warnings, err := v.ValidateCreate(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	found := false
+	for _, w := range warnings {
+		if strings.Contains(w, "does-not-exist") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected a warning naming the missing webhookServerRef, got %v", warnings)
+	}
+}
+
+func TestCRDConversionConfigValidator_LiveSchemaValidationFailure_Rejected(t *testing.T) {
+	crd := establishedCRD("foos.example.org")
+	c := newFakeClient(crd).Build()
+	v := &CRDConversionConfigValidator{Client: c, Enabled: true}
+	cfg := renameRuleCRDConfig("cfg", "foos.example.org")
+	cfg.Spec.Spokes[0].Rules[0].FieldRename.HubPath = "spec.doesNotExist"
+	if _, err := v.ValidateCreate(context.Background(), cfg); err == nil {
+		t.Fatalf("expected an error when the config doesn't validate against the live CRD schema")
+	}
+}
+
+func TestCRDConversionConfigValidator_HappyPath_NoErrorNoWarnings(t *testing.T) {
+	crd := establishedCRD("foos.example.org")
+	c := newFakeClient(crd).Build()
+	v := &CRDConversionConfigValidator{Client: c, Enabled: true}
+	cfg := renameRuleCRDConfig("cfg", "foos.example.org")
+	warnings, err := v.ValidateCreate(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("expected no warnings for a fully well-formed, live-validated config, got %v", warnings)
+	}
+}
+
+func TestCRDConversionConfigValidator_ValidateDelete_AlwaysAllowed(t *testing.T) {
+	v := &CRDConversionConfigValidator{Client: newFakeClient().Build(), Enabled: false}
+	cfg := renameRuleCRDConfig("cfg", "foos.example.org")
+	if _, err := v.ValidateDelete(context.Background(), cfg); err != nil {
+		t.Fatalf("ValidateDelete must never reject, even when disabled: %v", err)
+	}
+}

--- a/internal/webhook/testutil_test.go
+++ b/internal/webhook/testutil_test.go
@@ -14,10 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package webhookserver
+package webhook
 
 import (
-	"github.com/prometheus/client_golang/prometheus"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -28,13 +27,6 @@ import (
 	teraskyv1alpha1 "github.com/terasky-oss/declarative-conversion-operator/api/v1alpha1"
 	"github.com/terasky-oss/declarative-conversion-operator/pkg/xrdadapter"
 )
-
-// newTestRegisterer returns a fresh, isolated Prometheus registry so
-// multiple tests can each construct their own Metrics without colliding
-// on the global default registry's metric names.
-func newTestRegisterer() prometheus.Registerer {
-	return prometheus.NewRegistry()
-}
 
 func newScheme() *runtime.Scheme {
 	s := runtime.NewScheme()
@@ -54,10 +46,10 @@ func newFakeClient(objs ...runtime.Object) *fake.ClientBuilder {
 	return fake.NewClientBuilder().WithScheme(newScheme()).WithRuntimeObjects(objs...)
 }
 
-// establishedXRD mirrors the fixture of the same name in
-// internal/controller and internal/webhook: a hub version (v2) and a spoke
-// version (v1) differing by one renamed field, with a live schema
-// engine.Analyze can validate rules against.
+// establishedXRD mirrors internal/controller's fixture of the same name: a
+// hub version (v2) and a spoke version (v1) that differ by exactly one
+// renamed field, with a live schema an engine.Analyze call can validate
+// rules against.
 func establishedXRD(name string) *unstructured.Unstructured {
 	xrd := &unstructured.Unstructured{Object: map[string]any{
 		"metadata": map[string]any{"name": name, "generation": int64(1)},

--- a/internal/webhook/xrdconversionconfig_webhook_validate_test.go
+++ b/internal/webhook/xrdconversionconfig_webhook_validate_test.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2026 The declarative-conversion-operator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	teraskyv1alpha1 "github.com/terasky-oss/declarative-conversion-operator/api/v1alpha1"
+)
+
+func TestXRDConversionConfigValidator_Disabled_Rejected(t *testing.T) {
+	c := newFakeClient().Build()
+	v := &XRDConversionConfigValidator{Client: c, Enabled: false}
+	cfg := renameRuleXRDConfig("cfg", "xfoos.example.org")
+	if _, err := v.ValidateCreate(context.Background(), cfg); err == nil {
+		t.Fatalf("expected an error when XRD support is disabled")
+	}
+}
+
+func TestXRDConversionConfigValidator_DuplicateTarget_Rejected(t *testing.T) {
+	existing := renameRuleXRDConfig("existing", "xfoos.example.org")
+	c := newFakeClient(existing).Build()
+	v := &XRDConversionConfigValidator{Client: c, Enabled: true}
+	cfg := renameRuleXRDConfig("cfg", "xfoos.example.org") // same target
+	if _, err := v.ValidateCreate(context.Background(), cfg); err == nil {
+		t.Fatalf("expected an error: only one config per XRD is supported")
+	}
+}
+
+func TestXRDConversionConfigValidator_TargetMissing_WarnsAndSkipsLiveValidation(t *testing.T) {
+	c := newFakeClient().Build()
+	v := &XRDConversionConfigValidator{Client: c, Enabled: true}
+	cfg := renameRuleXRDConfig("cfg", "missing.example.org")
+	warnings, err := v.ValidateCreate(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("unexpected error when the target XRD doesn't exist yet: %v", err)
+	}
+	if len(warnings) == 0 {
+		t.Fatalf("expected a warning about the missing target XRD")
+	}
+}
+
+func TestXRDConversionConfigValidator_WebhookServerRefMissing_Warns(t *testing.T) {
+	xrd := establishedXRD("xfoos.example.org")
+	c := newFakeClient(xrd).Build()
+	v := &XRDConversionConfigValidator{Client: c, Enabled: true}
+	cfg := renameRuleXRDConfig("cfg", "xfoos.example.org")
+	cfg.Spec.WebhookServerRef = &teraskyv1alpha1.WebhookServerRef{Name: "does-not-exist"}
+	warnings, err := v.ValidateCreate(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	found := false
+	for _, w := range warnings {
+		if strings.Contains(w, "does-not-exist") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected a warning naming the missing webhookServerRef, got %v", warnings)
+	}
+}
+
+func TestXRDConversionConfigValidator_LiveSchemaValidationFailure_Rejected(t *testing.T) {
+	xrd := establishedXRD("xfoos.example.org")
+	c := newFakeClient(xrd).Build()
+	v := &XRDConversionConfigValidator{Client: c, Enabled: true}
+	cfg := renameRuleXRDConfig("cfg", "xfoos.example.org")
+	cfg.Spec.Spokes[0].Rules[0].FieldRename.HubPath = "spec.doesNotExist" // hub field that isn't in the live schema
+	if _, err := v.ValidateCreate(context.Background(), cfg); err == nil {
+		t.Fatalf("expected an error when the config doesn't validate against the live XRD schema")
+	}
+}
+
+func TestXRDConversionConfigValidator_HappyPath_NoErrorNoWarnings(t *testing.T) {
+	xrd := establishedXRD("xfoos.example.org")
+	c := newFakeClient(xrd).Build()
+	v := &XRDConversionConfigValidator{Client: c, Enabled: true}
+	cfg := renameRuleXRDConfig("cfg", "xfoos.example.org")
+	warnings, err := v.ValidateCreate(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("expected no warnings for a fully well-formed, live-validated config, got %v", warnings)
+	}
+}
+
+func TestXRDConversionConfigValidator_ValidateDelete_AlwaysAllowed(t *testing.T) {
+	v := &XRDConversionConfigValidator{Client: newFakeClient().Build(), Enabled: false}
+	cfg := renameRuleXRDConfig("cfg", "xfoos.example.org")
+	if _, err := v.ValidateDelete(context.Background(), cfg); err != nil {
+		t.Fatalf("ValidateDelete must never reject, even when disabled: %v", err)
+	}
+}

--- a/internal/webhookserver/certreload_test.go
+++ b/internal/webhookserver/certreload_test.go
@@ -1,0 +1,180 @@
+/*
+Copyright 2026 The declarative-conversion-operator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhookserver
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// writeSelfSignedCert generates a throwaway self-signed ECDSA certificate
+// and writes tls.crt/tls.key into dir, mimicking what cert-manager mounts.
+func writeSelfSignedCert(t *testing.T, dir string, notAfter time.Time) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generating key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     notAfter,
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("creating certificate: %v", err)
+	}
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshaling key: %v", err)
+	}
+
+	var certBuf, keyBuf bytes.Buffer
+	if err := pem.Encode(&certBuf, &pem.Block{Type: "CERTIFICATE", Bytes: der}); err != nil {
+		t.Fatalf("encoding cert: %v", err)
+	}
+	if err := pem.Encode(&keyBuf, &pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}); err != nil {
+		t.Fatalf("encoding key: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "tls.crt"), certBuf.Bytes(), 0o600); err != nil {
+		t.Fatalf("writing tls.crt: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "tls.key"), keyBuf.Bytes(), 0o600); err != nil {
+		t.Fatalf("writing tls.key: %v", err)
+	}
+}
+
+func TestNewCertReloader_LoadsInitialCertificate(t *testing.T) {
+	dir := t.TempDir()
+	writeSelfSignedCert(t, dir, time.Now().Add(24*time.Hour))
+
+	r, err := NewCertReloader(dir, time.Hour)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	cert, err := r.GetCertificate(nil)
+	if err != nil {
+		t.Fatalf("unexpected error from GetCertificate: %v", err)
+	}
+	if cert == nil {
+		t.Fatalf("expected a non-nil certificate")
+	}
+	if r.LastError() != nil {
+		t.Fatalf("expected no reload error, got %v", r.LastError())
+	}
+}
+
+func TestNewCertReloader_MissingFiles_Errors(t *testing.T) {
+	dir := t.TempDir() // empty: no tls.crt/tls.key
+	if _, err := NewCertReloader(dir, time.Hour); err == nil {
+		t.Fatalf("expected an error when the certificate files don't exist")
+	}
+}
+
+func TestCertReloader_GetCertificate_BeforeAnyLoad(t *testing.T) {
+	r := &CertReloader{}
+	if _, err := r.GetCertificate(nil); err == nil {
+		t.Fatalf("expected an error before any certificate has been loaded")
+	}
+}
+
+func TestCertReloader_Reload_PicksUpRotatedCertificate(t *testing.T) {
+	dir := t.TempDir()
+	writeSelfSignedCert(t, dir, time.Now().Add(24*time.Hour))
+
+	r, err := NewCertReloader(dir, time.Hour)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	first, _ := r.GetCertificate(nil)
+
+	// Rotate: write a brand-new cert/key pair over the same paths.
+	writeSelfSignedCert(t, dir, time.Now().Add(48*time.Hour))
+	if err := r.reload(); err != nil {
+		t.Fatalf("unexpected reload error: %v", err)
+	}
+	second, _ := r.GetCertificate(nil)
+	if bytes.Equal(first.Certificate[0], second.Certificate[0]) {
+		t.Fatalf("expected the reloaded certificate to differ from the original")
+	}
+}
+
+func TestCertReloader_Reload_FailurePreservesLastGood(t *testing.T) {
+	dir := t.TempDir()
+	writeSelfSignedCert(t, dir, time.Now().Add(24*time.Hour))
+	r, err := NewCertReloader(dir, time.Hour)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	good, _ := r.GetCertificate(nil)
+
+	// Corrupt the key file so the next reload fails.
+	if err := os.WriteFile(filepath.Join(dir, "tls.key"), []byte("not a key"), 0o600); err != nil {
+		t.Fatalf("corrupting key: %v", err)
+	}
+	if err := r.reload(); err == nil {
+		t.Fatalf("expected reload to fail against a corrupted key")
+	}
+	if r.LastError() == nil {
+		t.Fatalf("expected LastError to be set after a failed reload")
+	}
+
+	stillGood, _ := r.GetCertificate(nil)
+	if !bytes.Equal(good.Certificate[0], stillGood.Certificate[0]) {
+		t.Fatalf("expected the last known-good certificate to keep being served after a failed reload")
+	}
+}
+
+func TestCertReloader_Run_StopsOnContextCancel(t *testing.T) {
+	dir := t.TempDir()
+	writeSelfSignedCert(t, dir, time.Now().Add(24*time.Hour))
+	r, err := NewCertReloader(dir, time.Millisecond)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		r.Run(ctx)
+		close(done)
+	}()
+
+	// Let at least one tick fire against a real cert-reload cycle before
+	// stopping, so this also incidentally exercises Run's ticker branch.
+	time.Sleep(5 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatalf("expected Run to return promptly after context cancellation")
+	}
+}

--- a/internal/webhookserver/reconciler_test.go
+++ b/internal/webhookserver/reconciler_test.go
@@ -1,0 +1,240 @@
+/*
+Copyright 2026 The declarative-conversion-operator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhookserver
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	teraskyv1alpha1 "github.com/terasky-oss/declarative-conversion-operator/api/v1alpha1"
+)
+
+func TestReconcileOneXRD_HappyPath_Compiles(t *testing.T) {
+	xrd := establishedXRD("xfoos.example.org")
+	cfg := renameRuleXRDConfig("cfg", "xfoos.example.org")
+	server := &teraskyv1alpha1.ConversionWebhookServer{}
+	server.Name = "srv"
+	server.Spec.Default = true
+
+	c := newFakeClient(xrd, cfg, server).Build()
+	r := &Reconciler{Client: c, ServerName: "srv", Registry: NewRegistry(), EnableXRDSupport: true}
+
+	if err := r.reconcileOneXRD(context.Background(), "cfg"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	entry, ok := r.Registry.Get("xfoos.example.org")
+	if !ok || entry.Router == nil {
+		t.Fatalf("expected a compiled entry to be registered, got ok=%v entry=%+v", ok, entry)
+	}
+	if entry.Router.Hub != "v2" {
+		t.Fatalf("unexpected hub version: %q", entry.Router.Hub)
+	}
+}
+
+func TestReconcileOneXRD_ConfigNotFound_Forgets(t *testing.T) {
+	c := newFakeClient().Build()
+	r := &Reconciler{Client: c, ServerName: "srv", Registry: NewRegistry(), EnableXRDSupport: true}
+	r.ensureConfigToTarget()
+	r.configToTarget[configKey("xrd", "cfg")] = "xfoos.example.org"
+	r.Registry.Set("xfoos.example.org", &CompiledEntry{})
+
+	if err := r.reconcileOneXRD(context.Background(), "cfg"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := r.Registry.Get("xfoos.example.org"); ok {
+		t.Fatalf("expected the registry entry to be removed once the config is gone")
+	}
+}
+
+func TestReconcileOneXRD_DeletionTimestamp_Forgets(t *testing.T) {
+	xrd := establishedXRD("xfoos.example.org")
+	cfg := renameRuleXRDConfig("cfg", "xfoos.example.org")
+	now := metav1.Now()
+	cfg.DeletionTimestamp = &now
+	cfg.Finalizers = []string{"keep-it-around-for-the-fake-client"}
+
+	c := newFakeClient(xrd, cfg).Build()
+	r := &Reconciler{Client: c, ServerName: "srv", Registry: NewRegistry(), EnableXRDSupport: true}
+	r.ensureConfigToTarget()
+	r.configToTarget[configKey("xrd", "cfg")] = "xfoos.example.org"
+	r.Registry.Set("xfoos.example.org", &CompiledEntry{})
+
+	if err := r.reconcileOneXRD(context.Background(), "cfg"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := r.Registry.Get("xfoos.example.org"); ok {
+		t.Fatalf("expected the registry entry to be removed for a config being deleted")
+	}
+}
+
+func TestReconcileOneXRD_NotAssignedToThisReplica_Removed(t *testing.T) {
+	xrd := establishedXRD("xfoos.example.org")
+	cfg := renameRuleXRDConfig("cfg", "xfoos.example.org")
+	otherServer := &teraskyv1alpha1.ConversionWebhookServer{}
+	otherServer.Name = "other-srv"
+	otherServer.Spec.Default = true
+
+	c := newFakeClient(xrd, cfg, otherServer).Build()
+	registry := NewRegistry()
+	registry.Set("xfoos.example.org", &CompiledEntry{Router: nil})
+	r := &Reconciler{Client: c, ServerName: "this-srv", Registry: registry, EnableXRDSupport: true}
+
+	if err := r.reconcileOneXRD(context.Background(), "cfg"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := r.Registry.Get("xfoos.example.org"); ok {
+		t.Fatalf("expected the entry to be removed since the config resolves to a different replica")
+	}
+}
+
+func TestReconcileOneXRD_TargetXRDMissing_RecordsFailure(t *testing.T) {
+	cfg := renameRuleXRDConfig("cfg", "missing.example.org")
+	server := &teraskyv1alpha1.ConversionWebhookServer{}
+	server.Name = "srv"
+	server.Spec.Default = true
+
+	c := newFakeClient(cfg, server).Build()
+	r := &Reconciler{Client: c, ServerName: "srv", Registry: NewRegistry(), EnableXRDSupport: true}
+
+	if err := r.reconcileOneXRD(context.Background(), "cfg"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	entry, ok := r.Registry.Get("missing.example.org")
+	if !ok || entry.LastError == "" {
+		t.Fatalf("expected a placeholder entry recording the missing-XRD failure, got ok=%v entry=%+v", ok, entry)
+	}
+}
+
+func TestReconcileOneXRD_InvalidRules_RecordsFailure(t *testing.T) {
+	xrd := establishedXRD("xfoos.example.org")
+	cfg := renameRuleXRDConfig("cfg", "xfoos.example.org")
+	cfg.Spec.Spokes[0].Rules[0].FieldRename = nil // strategy declared, no matching params
+	server := &teraskyv1alpha1.ConversionWebhookServer{}
+	server.Name = "srv"
+	server.Spec.Default = true
+
+	c := newFakeClient(xrd, cfg, server).Build()
+	r := &Reconciler{Client: c, ServerName: "srv", Registry: NewRegistry(), EnableXRDSupport: true}
+
+	if err := r.reconcileOneXRD(context.Background(), "cfg"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	entry, ok := r.Registry.Get("xfoos.example.org")
+	if !ok || entry.LastError == "" {
+		t.Fatalf("expected a recorded failure for invalid rules, got ok=%v entry=%+v", ok, entry)
+	}
+}
+
+func TestReconcileOneXRD_AnalysisErrors_RecordsFailure(t *testing.T) {
+	xrd := establishedXRD("xfoos.example.org")
+	cfg := renameRuleXRDConfig("cfg", "xfoos.example.org")
+	cfg.Spec.Spokes[0].Rules[0].FieldRename.HubPath = "spec.doesNotExist"
+	server := &teraskyv1alpha1.ConversionWebhookServer{}
+	server.Name = "srv"
+	server.Spec.Default = true
+
+	c := newFakeClient(xrd, cfg, server).Build()
+	r := &Reconciler{Client: c, ServerName: "srv", Registry: NewRegistry(), EnableXRDSupport: true}
+
+	if err := r.reconcileOneXRD(context.Background(), "cfg"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	entry, ok := r.Registry.Get("xfoos.example.org")
+	if !ok || entry.LastError == "" {
+		t.Fatalf("expected a recorded failure when analysis reports validation errors, got ok=%v entry=%+v", ok, entry)
+	}
+}
+
+func TestReconcileOneCRD_HappyPath_Compiles(t *testing.T) {
+	crd := establishedCRD("foos.example.org")
+	cfg := renameRuleCRDConfig("cfg", "foos.example.org")
+	server := &teraskyv1alpha1.ConversionWebhookServer{}
+	server.Name = "srv"
+	server.Spec.Default = true
+
+	c := newFakeClient(crd, cfg, server).Build()
+	r := &Reconciler{Client: c, ServerName: "srv", Registry: NewRegistry(), EnableCRDSupport: true}
+
+	if err := r.reconcileOneCRD(context.Background(), "cfg"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	entry, ok := r.Registry.Get("foos.example.org")
+	if !ok || entry.Router == nil {
+		t.Fatalf("expected a compiled entry to be registered, got ok=%v entry=%+v", ok, entry)
+	}
+}
+
+func TestReconcileOneCRD_TargetCRDMissing_RecordsFailure(t *testing.T) {
+	cfg := renameRuleCRDConfig("cfg", "missing.example.org")
+	server := &teraskyv1alpha1.ConversionWebhookServer{}
+	server.Name = "srv"
+	server.Spec.Default = true
+
+	c := newFakeClient(cfg, server).Build()
+	r := &Reconciler{Client: c, ServerName: "srv", Registry: NewRegistry(), EnableCRDSupport: true}
+
+	if err := r.reconcileOneCRD(context.Background(), "cfg"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	entry, ok := r.Registry.Get("missing.example.org")
+	if !ok || entry.LastError == "" {
+		t.Fatalf("expected a placeholder entry recording the missing-CRD failure, got ok=%v entry=%+v", ok, entry)
+	}
+}
+
+func TestInitialSync_PopulatesRegistryForEnabledKinds(t *testing.T) {
+	xrd := establishedXRD("xfoos.example.org")
+	xrdCfg := renameRuleXRDConfig("xrd-cfg", "xfoos.example.org")
+	crd := establishedCRD("foos.example.org")
+	crdCfg := renameRuleCRDConfig("crd-cfg", "foos.example.org")
+	server := &teraskyv1alpha1.ConversionWebhookServer{}
+	server.Name = "srv"
+	server.Spec.Default = true
+
+	c := newFakeClient(xrd, xrdCfg, crd, crdCfg, server).Build()
+	r := &Reconciler{Client: c, ServerName: "srv", Registry: NewRegistry(), EnableXRDSupport: true, EnableCRDSupport: true}
+
+	if err := r.InitialSync(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := r.Registry.Get("xfoos.example.org"); !ok {
+		t.Fatalf("expected the XRD's config to have been synced")
+	}
+	if _, ok := r.Registry.Get("foos.example.org"); !ok {
+		t.Fatalf("expected the CRD's config to have been synced")
+	}
+}
+
+func TestInitialSync_DisabledKindsAreSkipped(t *testing.T) {
+	xrd := establishedXRD("xfoos.example.org")
+	xrdCfg := renameRuleXRDConfig("xrd-cfg", "xfoos.example.org")
+	server := &teraskyv1alpha1.ConversionWebhookServer{}
+	server.Name = "srv"
+	server.Spec.Default = true
+
+	c := newFakeClient(xrd, xrdCfg, server).Build()
+	r := &Reconciler{Client: c, ServerName: "srv", Registry: NewRegistry(), EnableXRDSupport: false, EnableCRDSupport: false}
+
+	if err := r.InitialSync(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r.Registry.Len() != 0 {
+		t.Fatalf("expected nothing to sync when both kinds are disabled, got len=%d", r.Registry.Len())
+	}
+}

--- a/internal/webhookserver/registry_test.go
+++ b/internal/webhookserver/registry_test.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2026 The declarative-conversion-operator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhookserver
+
+import "testing"
+
+func TestRegistry_GetSet(t *testing.T) {
+	r := NewRegistry()
+	if _, ok := r.Get("missing"); ok {
+		t.Fatalf("expected no entry in a fresh registry")
+	}
+	entry := &CompiledEntry{PlanHash: "abc"}
+	r.Set("xfoos.example.org", entry)
+	got, ok := r.Get("xfoos.example.org")
+	if !ok || got.PlanHash != "abc" {
+		t.Fatalf("unexpected Get result: ok=%v got=%+v", ok, got)
+	}
+	if r.Len() != 1 {
+		t.Fatalf("expected Len()=1, got %d", r.Len())
+	}
+}
+
+func TestRegistry_RecordError_CreatesPlaceholderWhenAbsent(t *testing.T) {
+	r := NewRegistry()
+	r.RecordError("xfoos.example.org", "boom")
+	entry, ok := r.Get("xfoos.example.org")
+	if !ok {
+		t.Fatalf("expected a placeholder entry to be created")
+	}
+	if entry.Router != nil {
+		t.Fatalf("expected a Router-less placeholder, got %+v", entry.Router)
+	}
+	if entry.LastError != "boom" {
+		t.Fatalf("unexpected LastError: %q", entry.LastError)
+	}
+	if entry.LastErrorAt.IsZero() {
+		t.Fatalf("expected LastErrorAt to be set")
+	}
+}
+
+func TestRegistry_Remove(t *testing.T) {
+	r := NewRegistry()
+	r.Set("xfoos.example.org", &CompiledEntry{})
+	r.Remove("xfoos.example.org")
+	if _, ok := r.Get("xfoos.example.org"); ok {
+		t.Fatalf("expected the entry to be gone after Remove")
+	}
+	if r.Len() != 0 {
+		t.Fatalf("expected Len()=0 after removing the only entry, got %d", r.Len())
+	}
+	// Removing an absent key must be a harmless no-op.
+	r.Remove("still-not-there")
+}
+
+func TestRegistry_Snapshot_IsACopy(t *testing.T) {
+	r := NewRegistry()
+	r.Set("xfoos.example.org", &CompiledEntry{PlanHash: "v1"})
+
+	snap := r.Snapshot()
+	if len(snap) != 1 {
+		t.Fatalf("expected 1 entry in the snapshot, got %d", len(snap))
+	}
+	// Mutating the map returned by Snapshot must not affect the registry.
+	delete(snap, "xfoos.example.org")
+	if r.Len() != 1 {
+		t.Fatalf("expected the registry to be unaffected by mutating a snapshot, got Len()=%d", r.Len())
+	}
+}

--- a/internal/webhookserver/server_test.go
+++ b/internal/webhookserver/server_test.go
@@ -19,9 +19,11 @@ package webhookserver
 import (
 	"bytes"
 	"encoding/json"
+	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -115,5 +117,156 @@ func TestRegistry_RecordErrorPreservesRouter(t *testing.T) {
 	}
 	if entry.PlanHash != "good" {
 		t.Fatalf("expected PlanHash to be preserved from the last good compile")
+	}
+}
+
+func TestHandleConvert_WrongMethod_Rejected(t *testing.T) {
+	s := &Server{Registry: NewRegistry()}
+	req := httptest.NewRequest("GET", "/convert/xfoos.example.org", nil)
+	rec := httptest.NewRecorder()
+	s.handleConvert(rec, req)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d", rec.Code)
+	}
+}
+
+func TestHandleConvert_MalformedBody_BadRequest(t *testing.T) {
+	s := &Server{Registry: NewRegistry()}
+	req := httptest.NewRequest("POST", "/convert/xfoos.example.org", bytes.NewReader([]byte("{not json")))
+	rec := httptest.NewRecorder()
+	s.handleConvert(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for malformed JSON, got %d", rec.Code)
+	}
+}
+
+func TestHandleConvert_MissingRequest_BadRequest(t *testing.T) {
+	s := &Server{Registry: NewRegistry()}
+	body, _ := json.Marshal(extv1.ConversionReview{}) // no .Request
+	req := httptest.NewRequest("POST", "/convert/xfoos.example.org", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	s.handleConvert(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 when .Request is nil, got %d", rec.Code)
+	}
+}
+
+func TestHandleConvert_NoCompiledPlanForRequestedVersion_FailsClosed(t *testing.T) {
+	hub, spoke := "v2", "v1"
+	plan := &engine.Plan{HubVersion: hub, SpokeVersion: spoke, HubToSpoke: []engine.Op{}, SpokeToHub: []engine.Op{}}
+	registry := NewRegistry()
+	registry.Set("xfoos.example.org", &CompiledEntry{Router: &engine.Router{Hub: hub, Plans: map[string]*engine.Plan{spoke: plan}}})
+	s := &Server{Registry: registry, Metrics: NewMetrics(newTestRegisterer())}
+
+	obj := map[string]any{"apiVersion": "example.org/v1", "kind": "Foo", "metadata": map[string]any{"name": "x"}}
+	raw, _ := json.Marshal(obj)
+	review := extv1.ConversionReview{Request: &extv1.ConversionRequest{
+		UID: "abc", DesiredAPIVersion: "example.org/v3", // v3 was never compiled
+		Objects: []runtime.RawExtension{{Raw: raw}},
+	}}
+	body, _ := json.Marshal(review)
+	req := httptest.NewRequest("POST", "/convert/xfoos.example.org", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	s.handleConvert(rec, req)
+
+	var got extv1.ConversionReview
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decoding response: %v", err)
+	}
+	if got.Response.Result.Status != metav1.StatusFailure {
+		t.Fatalf("expected a Failure result when the router has no plan for the requested version, got %+v", got.Response.Result)
+	}
+}
+
+func TestHandleConvert_LossyConversion_IncrementsMetric(t *testing.T) {
+	hub, spoke := "v2", "v1"
+	plan := &engine.Plan{HubVersion: hub, SpokeVersion: spoke, HubToSpoke: []engine.Op{}, SpokeToHub: []engine.Op{}}
+	registry := NewRegistry()
+	registry.Set("xfoos.example.org", &CompiledEntry{
+		Router:   &engine.Router{Hub: hub, Plans: map[string]*engine.Plan{spoke: plan}},
+		Lossless: map[string]engine.LosslessVerdict{spoke: {HubToSpoke: false, SpokeToHub: true}},
+	})
+	metrics := NewMetrics(newTestRegisterer())
+	s := &Server{Registry: registry, Metrics: metrics}
+
+	obj := map[string]any{"apiVersion": "example.org/v2", "kind": "Foo", "metadata": map[string]any{"name": "x"}}
+	raw, _ := json.Marshal(obj)
+	review := extv1.ConversionReview{Request: &extv1.ConversionRequest{
+		UID: "abc", DesiredAPIVersion: "example.org/v1", // hub -> spoke, the direction marked lossy above
+		Objects: []runtime.RawExtension{{Raw: raw}},
+	}}
+	body, _ := json.Marshal(review)
+	req := httptest.NewRequest("POST", "/convert/xfoos.example.org", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	s.handleConvert(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected the HTTP call itself to succeed, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if got := testutil.ToFloat64(metrics.LossyTotal.WithLabelValues("xfoos.example.org", "hub_to_spoke")); got != 1 {
+		t.Fatalf("expected the lossy-conversion counter to be incremented once, got %v", got)
+	}
+}
+
+func TestHandleReadyz(t *testing.T) {
+	s := &Server{Registry: NewRegistry(), Metrics: NewMetrics(newTestRegisterer())}
+	req := httptest.NewRequest("GET", "/readyz", nil)
+	rec := httptest.NewRecorder()
+	s.handleReadyz(rec, req)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503 before SetReady(true), got %d", rec.Code)
+	}
+
+	s.SetReady(true)
+	rec = httptest.NewRecorder()
+	s.handleReadyz(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 after SetReady(true), got %d", rec.Code)
+	}
+	if got := testutil.ToFloat64(s.Metrics.Ready); got != 1 {
+		t.Fatalf("expected the Ready gauge to be 1, got %v", got)
+	}
+
+	s.SetReady(false)
+	if got := testutil.ToFloat64(s.Metrics.Ready); got != 0 {
+		t.Fatalf("expected the Ready gauge to be 0 after SetReady(false), got %v", got)
+	}
+}
+
+func TestHandleDebugRegistry(t *testing.T) {
+	registry := NewRegistry()
+	registry.Set("compiled.example.org", &CompiledEntry{
+		Router:   &engine.Router{Hub: "v2", Plans: map[string]*engine.Plan{"v1": {}}},
+		PlanHash: "sha256:abc",
+	})
+	registry.RecordError("broken.example.org", "schema drift")
+	s := &Server{Registry: registry}
+
+	req := httptest.NewRequest("GET", "/debug/registry", nil)
+	rec := httptest.NewRecorder()
+	s.handleDebugRegistry(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	var entries []map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &entries); err != nil {
+		t.Fatalf("decoding response: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d: %v", len(entries), entries)
+	}
+	byXRD := map[string]map[string]any{}
+	for _, e := range entries {
+		byXRD[e["xrd"].(string)] = e
+	}
+	if !byXRD["compiled.example.org"]["ready"].(bool) {
+		t.Fatalf("expected compiled.example.org to be ready")
+	}
+	if byXRD["broken.example.org"]["ready"].(bool) {
+		t.Fatalf("expected broken.example.org (error-only placeholder) to be not ready")
+	}
+	if byXRD["broken.example.org"]["lastError"] != "schema drift" {
+		t.Fatalf("unexpected lastError: %v", byXRD["broken.example.org"]["lastError"])
 	}
 }


### PR DESCRIPTION
## Summary

Adds unit tests for the packages with the biggest legitimate gaps, using controller-runtime's fake client (with status-subresource support and both typed and unstructured server-side-apply) rather than envtest, so no cluster or kubebuilder binaries are needed to run any of this.

| Package | Before | After |
|---|---|---|
| `api/v1alpha1` | 0.0%* | 17.6% |
| `internal/controller` | 3.0% | 72.9% |
| `internal/webhook` | 27.1% | 80.7% |
| `internal/webhookserver` | 22.2% | 72.6% |
| `cmd/manager` | 0.0% | 12.1% |

\* `api/v1alpha1`'s conversion logic (`ToRuleSets`/`convertParams`) was already exercised transitively by `internal/webhook`'s and `internal/cli`'s tests, but Go's default per-package coverage accounting doesn't credit that — see the CI change below.

**What's covered now:**
- **`api/v1alpha1`**: table-driven tests for every `ConversionRule` strategy's happy path and missing-params error path, `ForEach` nesting, JSON value errors, and `ToRuleSets`/`spokesToRuleSets`.
- **`internal/controller`**: `Reconcile` tests for all three reconcilers (`XRDConversionConfig`, `CRDConversionConfig`, `ConversionWebhookServer`) — happy path, both drift policies, health gates, delete/finalizer flows, autoscaling/PDB toggling.
- **`internal/webhook`**: full `validate()` coverage for both config validators (disabled, duplicate target, missing refs, live schema validation) and complete tests for the previously-untested `ConversionWebhookServerValidator`.
- **`internal/webhookserver`**: a new `reconciler_test.go` for the previously-untested `Reconciler`, `certreload_test.go` (load/reload/rotation/failure-preserves-last-good), expanded `registry_test.go`, and `handleReadyz`/`handleDebugRegistry`/`handleConvert` edge cases.
- **`cmd/manager`**: `currentNamespace()`, the one unit-testable seam in `main()` — the rest is wiring already covered by the e2e suite (`hack/e2e-test*.sh`), which is the right place for it, not something this PR tries to duplicate.

**Whole-repo real coverage** (measured with `-coverpkg=./...`, which attributes a statement to the package it actually lives in even when only exercised by another package's tests) goes from **40.9% to 64.7%**.

**CI change**: `ci.yml` now measures coverage with `-coverpkg=./...` instead of Go's default same-package-only accounting (which was hiding the true coverage of library code like `api/v1alpha1`), and fails the build below 60% so this doesn't silently regress.

## Notes on what's *not* covered, and why

- `cmd/manager`/`cmd/webhook-server`'s `main()` wiring (manager bootstrap, flag parsing) is intentionally left to the e2e suite — that's what actually exercises it meaningfully.
- `api/v1alpha1/zz_generated.deepcopy.go` (controller-gen output) is conventionally never unit-tested and still drags down that package's own-package percentage; the CI gate accounts for this by targeting a whole-repo threshold rather than a per-package one.
- One fake-client fidelity gap surfaced while writing the `CRDConversionConfigReconciler` tests: its typed server-side-apply for `CustomResourceDefinition` doesn't preserve fields the applied config doesn't mention (`spec.versions` gets dropped) the way a real API server would. It's noted inline in the test that hit it; it only affects a same-object double-`Apply` sequence within one test run, not the reconciler code itself.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` clean
- [x] `go test ./... -race -count=1` all green
- [x] `go mod tidy` clean (one new indirect dep, `github.com/kylelemons/godebug`, pulled in by `prometheus/client_golang/prometheus/testutil`)
- [x] Verified the new CI coverage-gate shell logic against both a passing (64.7%) and failing (55%) total

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01C5viqwPWWu5VBMU2MkGzci)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for conversion rules, configuration validation, reconciliation, webhook behavior, certificate rotation, registry operations, namespace resolution, and HTTP endpoints.
  * Added scenarios for invalid configurations, deletion safeguards, readiness states, drift handling, error recovery, and malformed requests.

* **Chores**
  * CI now measures cross-package test coverage and requires at least 60% overall coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->