### PR TITLE
0.2: populate FieldsUncoveredHub/Spoke from diagnostics

### DIFF
--- a/internal/controller/crdconversionconfig_controller.go
+++ b/internal/controller/crdconversionconfig_controller.go
@@ -251,8 +251,10 @@ func populateCRDSpokeStatuses(cfg *teraskyv1alpha1.CRDConversionConfig, report e
 	statuses := make([]teraskyv1alpha1.SpokeConversionStatus, 0, len(report.SpokeReports))
 	for _, sr := range report.SpokeReports {
 		s := teraskyv1alpha1.SpokeConversionStatus{
-			Version:  sr.Version,
-			Lossless: teraskyv1alpha1.LosslessVerdict{HubToSpoke: sr.Lossless.HubToSpoke, SpokeToHub: sr.Lossless.SpokeToHub},
+			Version:              sr.Version,
+			Lossless:             teraskyv1alpha1.LosslessVerdict{HubToSpoke: sr.Lossless.HubToSpoke, SpokeToHub: sr.Lossless.SpokeToHub},
+			FieldsUncoveredHub:   sr.Uncovered.UncoveredHub,
+			FieldsUncoveredSpoke: sr.Uncovered.UncoveredSpoke,
 		}
 		for _, d := range sr.Errors {
 			s.Errors = append(s.Errors, d.Message)

--- a/internal/controller/crdconversionconfig_controller_test.go
+++ b/internal/controller/crdconversionconfig_controller_test.go
@@ -207,6 +207,82 @@ func TestCRDReconcile_Delete_UnsafeOverrideRemovesFinalizer(t *testing.T) {
 	}
 }
 
+// uncoveredFieldCRD is establishedCRD's counterpart with one extra
+// hub-only field ("spec.extraHub") and one extra spoke-only field
+// ("spec.extraSpoke"), neither of which any rule covers.
+func uncoveredFieldCRD(name string) *extv1.CustomResourceDefinition {
+	return &extv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Generation: 1},
+		Spec: extv1.CustomResourceDefinitionSpec{
+			Group: "example.org",
+			Names: extv1.CustomResourceDefinitionNames{Plural: "foos", Kind: "Foo"},
+			Scope: extv1.NamespaceScoped,
+			Versions: []extv1.CustomResourceDefinitionVersion{
+				{
+					Name: "v2", Served: true, Storage: true,
+					Schema: &extv1.CustomResourceValidation{OpenAPIV3Schema: &extv1.JSONSchemaProps{
+						Type: "object",
+						Properties: map[string]extv1.JSONSchemaProps{
+							"spec": {Type: "object", Properties: map[string]extv1.JSONSchemaProps{
+								"size":     {Type: "string"},
+								"extraHub": {Type: "string"},
+							}},
+						},
+					}},
+				},
+				{
+					Name: "v1", Served: true, Storage: false,
+					Schema: &extv1.CustomResourceValidation{OpenAPIV3Schema: &extv1.JSONSchemaProps{
+						Type: "object",
+						Properties: map[string]extv1.JSONSchemaProps{
+							"spec": {Type: "object", Properties: map[string]extv1.JSONSchemaProps{
+								"storageSize": {Type: "string"},
+								"extraSpoke":  {Type: "string"},
+							}},
+						},
+					}},
+				},
+			},
+		},
+		Status: extv1.CustomResourceDefinitionStatus{
+			Conditions: []extv1.CustomResourceDefinitionCondition{
+				{Type: extv1.Established, Status: extv1.ConditionTrue},
+			},
+		},
+	}
+}
+
+func TestCRDReconcile_UncoveredFields_PopulateStatus(t *testing.T) {
+	crd := uncoveredFieldCRD("foos.example.org")
+	cfg := renameRuleCRDConfig("cfg", "foos.example.org") // only maps spec.size<->spec.storageSize
+	server, secret := readyServer("srv")
+
+	c := newFakeClient(crd, cfg, server, secret).Build()
+	r := &CRDConversionConfigReconciler{Client: c, DefaultServerNamespace: "operator-ns"}
+
+	if _, err := reconcileCRD(t, r, "cfg"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := getCRDConfig(t, r, "cfg")
+
+	// Uncovered fields under the default Error policy fail validation, so
+	// the config never reaches Applied — but status.spokeStatuses must
+	// still be populated with exactly which leaf paths are uncovered.
+	if got.Status.Phase != teraskyv1alpha1.PhaseInvalid {
+		t.Fatalf("expected phase Invalid, got %q (message: %s)", got.Status.Phase, got.Status.Message)
+	}
+	if len(got.Status.SpokeStatuses) != 1 {
+		t.Fatalf("expected 1 spoke status, got %d", len(got.Status.SpokeStatuses))
+	}
+	ss := got.Status.SpokeStatuses[0]
+	if len(ss.FieldsUncoveredHub) != 1 || ss.FieldsUncoveredHub[0] != "spec.extraHub" {
+		t.Fatalf("expected FieldsUncoveredHub = [%q], got %v", "spec.extraHub", ss.FieldsUncoveredHub)
+	}
+	if len(ss.FieldsUncoveredSpoke) != 1 || ss.FieldsUncoveredSpoke[0] != "spec.extraSpoke" {
+		t.Fatalf("expected FieldsUncoveredSpoke = [%q], got %v", "spec.extraSpoke", ss.FieldsUncoveredSpoke)
+	}
+}
+
 func TestCRDReconcile_NotFound_IsIgnored(t *testing.T) {
 	c := newFakeClient().Build()
 	r := &CRDConversionConfigReconciler{Client: c, DefaultServerNamespace: "operator-ns"}

--- a/internal/controller/xrdconversionconfig_controller.go
+++ b/internal/controller/xrdconversionconfig_controller.go
@@ -264,8 +264,10 @@ func populateSpokeStatuses(cfg *teraskyv1alpha1.XRDConversionConfig, report engi
 	statuses := make([]teraskyv1alpha1.SpokeConversionStatus, 0, len(report.SpokeReports))
 	for _, sr := range report.SpokeReports {
 		s := teraskyv1alpha1.SpokeConversionStatus{
-			Version:  sr.Version,
-			Lossless: teraskyv1alpha1.LosslessVerdict{HubToSpoke: sr.Lossless.HubToSpoke, SpokeToHub: sr.Lossless.SpokeToHub},
+			Version:              sr.Version,
+			Lossless:             teraskyv1alpha1.LosslessVerdict{HubToSpoke: sr.Lossless.HubToSpoke, SpokeToHub: sr.Lossless.SpokeToHub},
+			FieldsUncoveredHub:   sr.Uncovered.UncoveredHub,
+			FieldsUncoveredSpoke: sr.Uncovered.UncoveredSpoke,
 		}
 		for _, d := range sr.Errors {
 			s.Errors = append(s.Errors, d.Message)

--- a/internal/controller/xrdconversionconfig_controller_reconcile_test.go
+++ b/internal/controller/xrdconversionconfig_controller_reconcile_test.go
@@ -352,6 +352,83 @@ func TestXRDReconcile_Delete_NeverAppliedSkipsRevert(t *testing.T) {
 	}
 }
 
+// uncoveredFieldXRD is establishedXRD's counterpart with one extra
+// hub-only field ("spec.extraHub") and one extra spoke-only field
+// ("spec.extraSpoke"), neither of which any rule covers.
+func uncoveredFieldXRD(name string) *unstructured.Unstructured {
+	xrd := &unstructured.Unstructured{Object: map[string]any{
+		"metadata": map[string]any{"name": name, "generation": int64(1)},
+		"spec": map[string]any{
+			"scope": "Namespaced",
+			"versions": []any{
+				map[string]any{
+					"name": "v2", "served": true, "referenceable": true,
+					"schema": map[string]any{"openAPIV3Schema": map[string]any{
+						"type": "object",
+						"properties": map[string]any{
+							"spec": map[string]any{"type": "object", "properties": map[string]any{
+								"size":     map[string]any{"type": "string"},
+								"extraHub": map[string]any{"type": "string"},
+							}},
+						},
+					}},
+				},
+				map[string]any{
+					"name": "v1", "served": true, "referenceable": false,
+					"schema": map[string]any{"openAPIV3Schema": map[string]any{
+						"type": "object",
+						"properties": map[string]any{
+							"spec": map[string]any{"type": "object", "properties": map[string]any{
+								"storageSize": map[string]any{"type": "string"},
+								"extraSpoke":  map[string]any{"type": "string"},
+							}},
+						},
+					}},
+				},
+			},
+		},
+		"status": map[string]any{
+			"conditions": []any{map[string]any{"type": "Established", "status": "True"}},
+		},
+	}}
+	xrd.SetGroupVersionKind(xrdadapter.GroupVersionKind)
+	return xrd
+}
+
+func TestXRDReconcile_UncoveredFields_PopulateStatus(t *testing.T) {
+	xrd := uncoveredFieldXRD("xfoos.example.org")
+	cfg := renameRuleXRDConfig("cfg", "xfoos.example.org") // only maps spec.size<->spec.storageSize
+	server, secret := readyServer("srv")
+
+	c := newFakeClient(cfg, server, secret).Build()
+	if err := c.Create(context.Background(), xrd); err != nil {
+		t.Fatalf("creating XRD fixture: %v", err)
+	}
+	r := &XRDConversionConfigReconciler{Client: c, DefaultServerNamespace: "operator-ns"}
+
+	if _, err := reconcileXRD(t, r, "cfg"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := getXRDConfig(t, r, "cfg")
+
+	// Uncovered fields under the default Error policy fail validation, so
+	// the config never reaches Applied — but status.spokeStatuses must
+	// still be populated with exactly which leaf paths are uncovered.
+	if got.Status.Phase != teraskyv1alpha1.PhaseInvalid {
+		t.Fatalf("expected phase Invalid, got %q (message: %s)", got.Status.Phase, got.Status.Message)
+	}
+	if len(got.Status.SpokeStatuses) != 1 {
+		t.Fatalf("expected 1 spoke status, got %d", len(got.Status.SpokeStatuses))
+	}
+	ss := got.Status.SpokeStatuses[0]
+	if len(ss.FieldsUncoveredHub) != 1 || ss.FieldsUncoveredHub[0] != "spec.extraHub" {
+		t.Fatalf("expected FieldsUncoveredHub = [%q], got %v", "spec.extraHub", ss.FieldsUncoveredHub)
+	}
+	if len(ss.FieldsUncoveredSpoke) != 1 || ss.FieldsUncoveredSpoke[0] != "spec.extraSpoke" {
+		t.Fatalf("expected FieldsUncoveredSpoke = [%q], got %v", "spec.extraSpoke", ss.FieldsUncoveredSpoke)
+	}
+}
+
 func TestXRDReconcile_NotFound_IsIgnored(t *testing.T) {
 	c := newFakeClient().Build()
 	r := &XRDConversionConfigReconciler{Client: c, DefaultServerNamespace: "operator-ns"}

--- a/pkg/engine/analyze.go
+++ b/pkg/engine/analyze.go
@@ -80,7 +80,12 @@ func Analyze(in AnalyzeInput) (AnalyzeReport, error) {
 			if d.Severity == SeverityError {
 				sr.Errors = append(sr.Errors, d)
 				if d.FieldPath != "" {
-					sr.Uncovered.UncoveredHub = append(sr.Uncovered.UncoveredHub, d.FieldPath)
+					switch d.Side {
+					case FieldSideHub:
+						sr.Uncovered.UncoveredHub = append(sr.Uncovered.UncoveredHub, d.FieldPath)
+					case FieldSideSpoke:
+						sr.Uncovered.UncoveredSpoke = append(sr.Uncovered.UncoveredSpoke, d.FieldPath)
+					}
 				}
 			} else {
 				sr.Warnings = append(sr.Warnings, d)

--- a/pkg/engine/analyze_test.go
+++ b/pkg/engine/analyze_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2026 The declarative-conversion-operator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package engine
+
+import (
+	"testing"
+
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+func TestAnalyze_UncoveredFieldsRoutedBySide(t *testing.T) {
+	// "a" is identical on both sides (auto-covered, never uncovered).
+	// "hubOnly" exists only on the hub -> hub-side uncovered.
+	// "spokeOnly" exists only on the spoke -> spoke-side uncovered.
+	// "mismatched" exists on both sides but with incompatible types, so
+	// it's uncovered on BOTH sides simultaneously (one diagnostic from
+	// each of resolveAndBuildOps' two leftover-field loops).
+	hub := objSchema(map[string]extv1.JSONSchemaProps{
+		"a":          strSchema(),
+		"hubOnly":    strSchema(),
+		"mismatched": strSchema(),
+	})
+	spoke := objSchema(map[string]extv1.JSONSchemaProps{
+		"a":          strSchema(),
+		"spokeOnly":  strSchema(),
+		"mismatched": intSchema(),
+	})
+
+	source := fakeSource{versions: []VersionSchema{
+		{Name: "v2", Schema: &hub, Served: true, Storage: true},
+		{Name: "v1", Schema: &spoke, Served: true},
+	}}
+
+	report, err := Analyze(AnalyzeInput{
+		Source:     source,
+		HubVersion: "v2",
+		Spokes: []RuleSet{
+			{SpokeVersion: "v1"}, // no rules at all
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(report.SpokeReports) != 1 {
+		t.Fatalf("expected 1 spoke report, got %d", len(report.SpokeReports))
+	}
+	sr := report.SpokeReports[0]
+
+	wantHub := map[string]bool{"hubOnly": true, "mismatched": true}
+	if len(sr.Uncovered.UncoveredHub) != len(wantHub) {
+		t.Fatalf("UncoveredHub = %v, want exactly %v", sr.Uncovered.UncoveredHub, wantHub)
+	}
+	for _, p := range sr.Uncovered.UncoveredHub {
+		if !wantHub[p] {
+			t.Errorf("unexpected path %q in UncoveredHub (%v)", p, sr.Uncovered.UncoveredHub)
+		}
+	}
+
+	wantSpoke := map[string]bool{"spokeOnly": true, "mismatched": true}
+	if len(sr.Uncovered.UncoveredSpoke) != len(wantSpoke) {
+		t.Fatalf("UncoveredSpoke = %v, want exactly %v", sr.Uncovered.UncoveredSpoke, wantSpoke)
+	}
+	for _, p := range sr.Uncovered.UncoveredSpoke {
+		if !wantSpoke[p] {
+			t.Errorf("unexpected path %q in UncoveredSpoke (%v)", p, sr.Uncovered.UncoveredSpoke)
+		}
+	}
+
+	// "a" must never appear in either list — identical shape is auto-covered.
+	for _, p := range append(append([]string{}, sr.Uncovered.UncoveredHub...), sr.Uncovered.UncoveredSpoke...) {
+		if p == "a" {
+			t.Errorf("field %q should be auto-covered (identical shape) but was reported uncovered", p)
+		}
+	}
+}

--- a/pkg/engine/compile.go
+++ b/pkg/engine/compile.go
@@ -252,9 +252,9 @@ func resolveAndBuildOps(rules []Rule, hub, spoke *extv1.JSONSchemaProps, policy 
 			continue
 		}
 		if suppressUncovered {
-			diags = append(diags, warnf(-1, "hub field %q is not covered by any rule and has no identical counterpart in the spoke schema", key))
+			diags = append(diags, warnfField(-1, FieldSideHub, key, "hub field %q is not covered by any rule and has no identical counterpart in the spoke schema", key))
 		} else {
-			diags = append(diags, errorf(-1, "hub field %q is not covered by any rule and has no identical counterpart in the spoke schema", key))
+			diags = append(diags, errorfField(-1, FieldSideHub, key, "hub field %q is not covered by any rule and has no identical counterpart in the spoke schema", key))
 			verdict.HubToSpoke = false
 		}
 	}
@@ -264,9 +264,9 @@ func resolveAndBuildOps(rules []Rule, hub, spoke *extv1.JSONSchemaProps, policy 
 			continue
 		}
 		if suppressUncovered {
-			diags = append(diags, warnf(-1, "spoke field %q is not covered by any rule and has no identical counterpart in the hub schema", key))
+			diags = append(diags, warnfField(-1, FieldSideSpoke, key, "spoke field %q is not covered by any rule and has no identical counterpart in the hub schema", key))
 		} else {
-			diags = append(diags, errorf(-1, "spoke field %q is not covered by any rule and has no identical counterpart in the hub schema", key))
+			diags = append(diags, errorfField(-1, FieldSideSpoke, key, "spoke field %q is not covered by any rule and has no identical counterpart in the hub schema", key))
 			verdict.SpokeToHub = false
 		}
 	}

--- a/pkg/engine/diagnostics.go
+++ b/pkg/engine/diagnostics.go
@@ -26,12 +26,22 @@ const (
 	SeverityWarning Severity = "Warning"
 )
 
+// FieldSide identifies which side of a hub<->spoke conversion a Diagnostic's
+// FieldPath refers to, when it refers to one at all.
+type FieldSide string
+
+const (
+	FieldSideHub   FieldSide = "hub"
+	FieldSideSpoke FieldSide = "spoke"
+)
+
 // Diagnostic is one issue found while analyzing or compiling a RuleSet.
 type Diagnostic struct {
 	Severity  Severity
 	Message   string
-	RuleIndex int    // -1 if not associated with a specific rule
-	FieldPath string // empty if not associated with a specific field
+	RuleIndex int       // -1 if not associated with a specific rule
+	FieldPath string    // empty if not associated with a specific field
+	Side      FieldSide // which side FieldPath belongs to; empty if FieldPath is empty
 }
 
 func errorf(ruleIndex int, format string, args ...any) Diagnostic {
@@ -40,6 +50,18 @@ func errorf(ruleIndex int, format string, args ...any) Diagnostic {
 
 func warnf(ruleIndex int, format string, args ...any) Diagnostic {
 	return Diagnostic{Severity: SeverityWarning, Message: fmt.Sprintf(format, args...), RuleIndex: ruleIndex}
+}
+
+// errorfField is like errorf but also records which field/side the
+// diagnostic is about, so callers (e.g. Analyze) can route it into the
+// appropriate FieldCoverage bucket without parsing the message string.
+func errorfField(ruleIndex int, side FieldSide, fieldPath, format string, args ...any) Diagnostic {
+	return Diagnostic{Severity: SeverityError, Message: fmt.Sprintf(format, args...), RuleIndex: ruleIndex, FieldPath: fieldPath, Side: side}
+}
+
+// warnfField is the Warning counterpart to errorfField.
+func warnfField(ruleIndex int, side FieldSide, fieldPath, format string, args ...any) Diagnostic {
+	return Diagnostic{Severity: SeverityWarning, Message: fmt.Sprintf(format, args...), RuleIndex: ruleIndex, FieldPath: fieldPath, Side: side}
 }
 
 // LosslessVerdict records whether a mapping is lossless in each direction


### PR DESCRIPTION
Part of the Phase 0 epic (#5). Second PR in the stack — base is #86 (0.1); rebase this PR whenever #86 changes.

## What

`status.spokeStatuses[].fieldsUncoveredHub`/`fieldsUncoveredSpoke` were defined on `SpokeConversionStatus` but never populated by either reconciler. Root cause: the underlying engine plumbing was half-built and actually broken, not just unwired:

- `Diagnostic` had a `FieldPath` field ("empty if not associated with a specific field") that `errorf()`/`warnf()` never set — always empty.
- `analyze.go` had `if d.FieldPath != "" { sr.Uncovered.UncoveredHub = append(...) }` — dead code, since `FieldPath` was never populated by anything — and there was no equivalent branch for `UncoveredSpoke` at all, even though `FieldCoverage` already declared both fields.
- The actual uncovered-field diagnostics come from `compile.go`'s leftover-field scan (one loop over hub leaves, one over spoke leaves); neither set `FieldPath`, and there was no way to tell which loop a diagnostic came from — a field with a type/shape mismatch between hub and spoke schemas produces one uncovered diagnostic from **each** loop with the identical path string, so "side" needs to be tracked explicitly rather than inferred from the path alone.

## Fix

- `diagnostics.go`: add a `FieldSide` type (`FieldSideHub`/`FieldSideSpoke`) and a `Side` field on `Diagnostic`, plus `errorfField`/`warnfField` constructors that set `Severity`, `Message`, `RuleIndex`, `FieldPath`, and `Side` together.
- `compile.go`: switch the four leftover-field-scan call sites to the field-aware constructors.
- `analyze.go`: route each error diagnostic with a non-empty `FieldPath` into `UncoveredHub`/`UncoveredSpoke` based on `Side`, instead of the old dead branch.
- `xrdconversionconfig_controller.go` / `crdconversionconfig_controller.go`: wire `sr.Uncovered.UncoveredHub`/`UncoveredSpoke` onto the `SpokeConversionStatus` built each reconcile.

`Compile()`'s own return shape and behavior are unchanged — `Diagnostic` only gained optional metadata that `Analyze` now consumes.

## Testing

- `pkg/engine/analyze_test.go` (new): a hub-only-uncovered field, a spoke-only-uncovered field, and a mismatched-type field uncovered on both sides simultaneously all land in the correct list; an identical-shape field is never flagged.
- New reconcile tests (XRD and CRD) asserting `status.spokeStatuses[].fieldsUncoveredHub`/`fieldsUncoveredSpoke` reflect the actual uncovered leaf paths after a reconcile against a config with deliberately uncovered fields.
- `go build ./...`, `go vet ./...`, `gofmt -l .`, and `make test` all pass across every package.

Closes #7.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XDg3yjnmD6gSUBsUKb3HbL)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of uncovered fields during conversion validation.
  * Correctly distinguishes hub-only, spoke-only, and mismatched fields.
  * Conversion configurations now report precise uncovered field paths in status details.
  * Configurations with uncovered fields are correctly marked invalid under the default validation policy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->