### PR TITLE
0.1: require unmappedFieldReason when unmappedFieldPolicy is Warn

### DIFF
--- a/api/v1alpha1/crdconversionconfig_types.go
+++ b/api/v1alpha1/crdconversionconfig_types.go
@@ -56,6 +56,10 @@ type CRDConversionConfigSpec struct {
 	// +optional
 	// +kubebuilder:default=Error
 	UnmappedFieldPolicy UnmappedFieldPolicy `json:"unmappedFieldPolicy,omitempty"`
+	// UnmappedFieldReason is a human-readable justification for leaving
+	// one or more hub/spoke fields unclaimed. Required (and enforced by
+	// the admission webhook and convctl validate) when UnmappedFieldPolicy
+	// is Warn; ignored when the policy is Error (the default).
 	// +optional
 	UnmappedFieldReason string `json:"unmappedFieldReason,omitempty"`
 

--- a/api/v1alpha1/xrdconversionconfig_types.go
+++ b/api/v1alpha1/xrdconversionconfig_types.go
@@ -456,6 +456,10 @@ type XRDConversionConfigSpec struct {
 	// +optional
 	// +kubebuilder:default=Error
 	UnmappedFieldPolicy UnmappedFieldPolicy `json:"unmappedFieldPolicy,omitempty"`
+	// UnmappedFieldReason is a human-readable justification for leaving
+	// one or more hub/spoke fields unclaimed. Required (and enforced by
+	// the admission webhook and convctl validate) when UnmappedFieldPolicy
+	// is Warn; ignored when the policy is Error (the default).
 	// +optional
 	UnmappedFieldReason string `json:"unmappedFieldReason,omitempty"`
 

--- a/charts/declarative-conversion-operator/crds/terasky.com_crdconversionconfigs.yaml
+++ b/charts/declarative-conversion-operator/crds/terasky.com_crdconversionconfigs.yaml
@@ -670,6 +670,11 @@ spec:
                 - Warn
                 type: string
               unmappedFieldReason:
+                description: |-
+                  UnmappedFieldReason is a human-readable justification for leaving
+                  one or more hub/spoke fields unclaimed. Required (and enforced by
+                  the admission webhook and convctl validate) when UnmappedFieldPolicy
+                  is Warn; ignored when the policy is Error (the default).
                 type: string
               webhookServerRef:
                 description: |-

--- a/charts/declarative-conversion-operator/crds/terasky.com_xrdconversionconfigs.yaml
+++ b/charts/declarative-conversion-operator/crds/terasky.com_xrdconversionconfigs.yaml
@@ -670,6 +670,11 @@ spec:
                 - Warn
                 type: string
               unmappedFieldReason:
+                description: |-
+                  UnmappedFieldReason is a human-readable justification for leaving
+                  one or more hub/spoke fields unclaimed. Required (and enforced by
+                  the admission webhook and convctl validate) when UnmappedFieldPolicy
+                  is Warn; ignored when the policy is Error (the default).
                 type: string
               webhookServerRef:
                 description: |-

--- a/config/crd/bases/terasky.com_crdconversionconfigs.yaml
+++ b/config/crd/bases/terasky.com_crdconversionconfigs.yaml
@@ -670,6 +670,11 @@ spec:
                 - Warn
                 type: string
               unmappedFieldReason:
+                description: |-
+                  UnmappedFieldReason is a human-readable justification for leaving
+                  one or more hub/spoke fields unclaimed. Required (and enforced by
+                  the admission webhook and convctl validate) when UnmappedFieldPolicy
+                  is Warn; ignored when the policy is Error (the default).
                 type: string
               webhookServerRef:
                 description: |-

--- a/config/crd/bases/terasky.com_xrdconversionconfigs.yaml
+++ b/config/crd/bases/terasky.com_xrdconversionconfigs.yaml
@@ -670,6 +670,11 @@ spec:
                 - Warn
                 type: string
               unmappedFieldReason:
+                description: |-
+                  UnmappedFieldReason is a human-readable justification for leaving
+                  one or more hub/spoke fields unclaimed. Required (and enforced by
+                  the admission webhook and convctl validate) when UnmappedFieldPolicy
+                  is Warn; ignored when the policy is Error (the default).
                 type: string
               webhookServerRef:
                 description: |-

--- a/docs/configuration/xrdconversionconfig.md
+++ b/docs/configuration/xrdconversionconfig.md
@@ -36,6 +36,7 @@ spec:
 | `webhookServerRef` | Pins this config to a specific `ConversionWebhookServer` by name. Omit to use whichever instance has `spec.default: true`. |
 | `conversionReviewVersions` | The `ConversionReview` API versions the webhook accepts, passed through to the XRD's `spec.conversion.webhook.conversionReviewVersions`. |
 | `unmappedFieldPolicy` | `Error` (default): any hub or spoke field left unclaimed by a rule and not structurally identical on both sides fails validation — "unknown means assume lossy, never silently pass." `Warn` downgrades this to a warning; requires `unmappedFieldReason`. |
+| `unmappedFieldReason` | Human-readable justification for deliberately leaving fields unclaimed. **Required** when `unmappedFieldPolicy: Warn` — enforced by the admission webhook and `convctl validate`. Ignored when the policy is `Error`. |
 | `driftPolicy` | Governs what happens when the live XRD's schema no longer matches what this config last validated against — see [Drift handling](#drift-handling). |
 
 ## Rules

--- a/internal/webhook/xrdconversionconfig_webhook.go
+++ b/internal/webhook/xrdconversionconfig_webhook.go
@@ -30,6 +30,7 @@ package webhook
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
@@ -129,9 +130,13 @@ func summarizeErrors(report engine.AnalyzeReport) string {
 }
 
 // ValidateStructure catches shape problems the CRD's OpenAPI schema can't
-// express: duplicate spoke versions, a spoke equal to the hub, and
-// strategy/params mismatches (including recursively inside ForEach).
+// express: duplicate spoke versions, a spoke equal to the hub,
+// strategy/params mismatches (including recursively inside ForEach), and
+// UnmappedFieldPolicy=Warn without a justification reason.
 func ValidateStructure(cfg *teraskyv1alpha1.XRDConversionConfig) error {
+	if err := validateUnmappedFieldReason(cfg.Spec.UnmappedFieldPolicy, cfg.Spec.UnmappedFieldReason); err != nil {
+		return err
+	}
 	return validateSpokesStructure(cfg.Spec.HubVersion, cfg.Spec.Spokes)
 }
 
@@ -140,7 +145,21 @@ func ValidateStructure(cfg *teraskyv1alpha1.XRDConversionConfig) error {
 // rules a rule set must satisfy don't depend on whether it's converting an
 // XRD or a native CRD.
 func ValidateCRDStructure(cfg *teraskyv1alpha1.CRDConversionConfig) error {
+	if err := validateUnmappedFieldReason(cfg.Spec.UnmappedFieldPolicy, cfg.Spec.UnmappedFieldReason); err != nil {
+		return err
+	}
 	return validateSpokesStructure(cfg.Spec.HubVersion, cfg.Spec.Spokes)
+}
+
+// validateUnmappedFieldReason enforces the documented contract that
+// UnmappedFieldPolicy=Warn requires a non-empty UnmappedFieldReason.
+// Without this check the reason field is silent dead API surface: adopters
+// can set it (or omit it under Warn) and observe no behavior change.
+func validateUnmappedFieldReason(policy teraskyv1alpha1.UnmappedFieldPolicy, reason string) error {
+	if policy == teraskyv1alpha1.UnmappedFieldPolicyWarn && strings.TrimSpace(reason) == "" {
+		return fmt.Errorf("spec.unmappedFieldReason is required when spec.unmappedFieldPolicy is Warn")
+	}
+	return nil
 }
 
 func validateSpokesStructure(hubVersion string, spokes []teraskyv1alpha1.SpokeVersionRules) error {

--- a/internal/webhook/xrdconversionconfig_webhook_test.go
+++ b/internal/webhook/xrdconversionconfig_webhook_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package webhook
 
 import (
+	"strings"
 	"testing"
 
 	teraskyv1alpha1 "github.com/terasky-oss/declarative-conversion-operator/api/v1alpha1"
@@ -93,5 +94,52 @@ func TestValidateStructure_AcceptsWellFormedConfig(t *testing.T) {
 	}}
 	if err := ValidateStructure(cfg); err != nil {
 		t.Fatalf("unexpected error for a well-formed config: %v", err)
+	}
+}
+
+func TestValidateStructure_WarnPolicyRequiresReason(t *testing.T) {
+	cfg := &teraskyv1alpha1.XRDConversionConfig{Spec: teraskyv1alpha1.XRDConversionConfigSpec{
+		HubVersion:          "v2",
+		UnmappedFieldPolicy: teraskyv1alpha1.UnmappedFieldPolicyWarn,
+		Spokes: []teraskyv1alpha1.SpokeVersionRules{{
+			Version: "v1",
+			Rules: []teraskyv1alpha1.ConversionRule{{
+				Strategy:    teraskyv1alpha1.StrategyFieldRename,
+				FieldRename: &teraskyv1alpha1.FieldRenameParams{HubPath: "a", SpokePath: "b"},
+			}},
+		}},
+	}}
+	err := ValidateStructure(cfg)
+	if err == nil {
+		t.Fatalf("expected error when UnmappedFieldPolicy=Warn without UnmappedFieldReason")
+	}
+	if !strings.Contains(err.Error(), "unmappedFieldReason") {
+		t.Fatalf("expected error to name unmappedFieldReason, got: %v", err)
+	}
+
+	cfg.Spec.UnmappedFieldReason = "intentionally leaving legacy fields unclaimed during migration"
+	if err := ValidateStructure(cfg); err != nil {
+		t.Fatalf("unexpected error when reason is provided: %v", err)
+	}
+}
+
+func TestValidateCRDStructure_WarnPolicyRequiresReason(t *testing.T) {
+	cfg := &teraskyv1alpha1.CRDConversionConfig{Spec: teraskyv1alpha1.CRDConversionConfigSpec{
+		HubVersion:          "v2",
+		UnmappedFieldPolicy: teraskyv1alpha1.UnmappedFieldPolicyWarn,
+		Spokes: []teraskyv1alpha1.SpokeVersionRules{{
+			Version: "v1",
+			Rules: []teraskyv1alpha1.ConversionRule{{
+				Strategy:    teraskyv1alpha1.StrategyFieldRename,
+				FieldRename: &teraskyv1alpha1.FieldRenameParams{HubPath: "a", SpokePath: "b"},
+			}},
+		}},
+	}}
+	if err := ValidateCRDStructure(cfg); err == nil {
+		t.Fatalf("expected error when UnmappedFieldPolicy=Warn without UnmappedFieldReason")
+	}
+	cfg.Spec.UnmappedFieldReason = "migration window"
+	if err := ValidateCRDStructure(cfg); err != nil {
+		t.Fatalf("unexpected error when reason is provided: %v", err)
 	}
 }

--- a/internal/webhook/xrdconversionconfig_webhook_test.go
+++ b/internal/webhook/xrdconversionconfig_webhook_test.go
@@ -117,6 +117,15 @@ func TestValidateStructure_WarnPolicyRequiresReason(t *testing.T) {
 		t.Fatalf("expected error to name unmappedFieldReason, got: %v", err)
 	}
 
+	cfg.Spec.UnmappedFieldReason = " \t\n"
+	err = ValidateStructure(cfg)
+	if err == nil {
+		t.Fatalf("expected error for whitespace-only UnmappedFieldReason")
+	}
+	if !strings.Contains(err.Error(), "unmappedFieldReason") {
+		t.Fatalf("expected error to name unmappedFieldReason, got: %v", err)
+	}
+
 	cfg.Spec.UnmappedFieldReason = "intentionally leaving legacy fields unclaimed during migration"
 	if err := ValidateStructure(cfg); err != nil {
 		t.Fatalf("unexpected error when reason is provided: %v", err)
@@ -138,6 +147,12 @@ func TestValidateCRDStructure_WarnPolicyRequiresReason(t *testing.T) {
 	if err := ValidateCRDStructure(cfg); err == nil {
 		t.Fatalf("expected error when UnmappedFieldPolicy=Warn without UnmappedFieldReason")
 	}
+
+	cfg.Spec.UnmappedFieldReason = " \t\n"
+	if err := ValidateCRDStructure(cfg); err == nil {
+		t.Fatalf("expected error for whitespace-only UnmappedFieldReason")
+	}
+
 	cfg.Spec.UnmappedFieldReason = "migration window"
 	if err := ValidateCRDStructure(cfg); err != nil {
 		t.Fatalf("unexpected error when reason is provided: %v", err)


### PR DESCRIPTION
## Summary
- Enforce the documented contract that `spec.unmappedFieldReason` is required when `spec.unmappedFieldPolicy: Warn`, in `ValidateStructure` / `ValidateCRDStructure` (admission webhook + `convctl validate`).
- Document the field explicitly in `docs/configuration/xrdconversionconfig.md` and CRD type godoc so the API surface is no longer silent dead weight.

Closes #6

## Test plan
- [x] `go test ./internal/webhook/... ./api/v1alpha1/...`
- [x] `make test`
- [x] `make test-e2e` (all 23 strategies passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added validation requiring a non-empty, human-readable reason when unmapped fields use the **Warn** policy.
  - Applies to both XRD and CRD conversion configurations.

- **Documentation**
  - Clarified that the reason is required with **Warn** and ignored with **Error** across configuration guides and schemas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->