### PR TITLE
0.2: populate status.spokeStatuses[].fieldsUncovered*

### DIFF
--- a/internal/controller/crdconversionconfig_controller.go
+++ b/internal/controller/crdconversionconfig_controller.go
@@ -251,8 +251,10 @@ func populateCRDSpokeStatuses(cfg *teraskyv1alpha1.CRDConversionConfig, report e
 	statuses := make([]teraskyv1alpha1.SpokeConversionStatus, 0, len(report.SpokeReports))
 	for _, sr := range report.SpokeReports {
 		s := teraskyv1alpha1.SpokeConversionStatus{
-			Version:  sr.Version,
-			Lossless: teraskyv1alpha1.LosslessVerdict{HubToSpoke: sr.Lossless.HubToSpoke, SpokeToHub: sr.Lossless.SpokeToHub},
+			Version:              sr.Version,
+			Lossless:             teraskyv1alpha1.LosslessVerdict{HubToSpoke: sr.Lossless.HubToSpoke, SpokeToHub: sr.Lossless.SpokeToHub},
+			FieldsUncoveredHub:   sr.Uncovered.UncoveredHub,
+			FieldsUncoveredSpoke: sr.Uncovered.UncoveredSpoke,
 		}
 		for _, d := range sr.Errors {
 			s.Errors = append(s.Errors, d.Message)

--- a/internal/controller/crdconversionconfig_controller_test.go
+++ b/internal/controller/crdconversionconfig_controller_test.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"reflect"
 	"testing"
 
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -28,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	teraskyv1alpha1 "github.com/terasky-oss/declarative-conversion-operator/api/v1alpha1"
+	"github.com/terasky-oss/declarative-conversion-operator/pkg/engine"
 )
 
 func reconcileCRD(t *testing.T, r *CRDConversionConfigReconciler, name string) (reconcile.Result, error) {
@@ -212,5 +214,34 @@ func TestCRDReconcile_NotFound_IsIgnored(t *testing.T) {
 	r := &CRDConversionConfigReconciler{Client: c, DefaultServerNamespace: "operator-ns"}
 	if _, err := reconcileCRD(t, r, "does-not-exist"); err != nil {
 		t.Fatalf("expected a NotFound Get to be swallowed, got %v", err)
+	}
+}
+
+func TestPopulateCRDSpokeStatuses_CopiesUncoveredFields(t *testing.T) {
+	cfg := &teraskyv1alpha1.CRDConversionConfig{}
+	report := engine.AnalyzeReport{
+		SpokeReports: []engine.SpokeReport{{
+			Version:  "v1beta1",
+			Lossless: engine.LosslessVerdict{HubToSpoke: true, SpokeToHub: true},
+			Uncovered: engine.FieldCoverage{
+				UncoveredHub:   []string{"spec.hubOnly"},
+				UncoveredSpoke: []string{"spec.spokeOnly"},
+			},
+			Warnings: []engine.Diagnostic{{
+				Severity: engine.SeverityWarning,
+				Message:  `hub field "spec.hubOnly" is not covered by any rule and has no identical counterpart in the spoke schema`,
+			}},
+		}},
+	}
+	populateCRDSpokeStatuses(cfg, report)
+	if len(cfg.Status.SpokeStatuses) != 1 {
+		t.Fatalf("expected 1 spoke status, got %d", len(cfg.Status.SpokeStatuses))
+	}
+	s := cfg.Status.SpokeStatuses[0]
+	if !reflect.DeepEqual(s.FieldsUncoveredHub, []string{"spec.hubOnly"}) {
+		t.Fatalf("FieldsUncoveredHub = %#v, want [spec.hubOnly]", s.FieldsUncoveredHub)
+	}
+	if !reflect.DeepEqual(s.FieldsUncoveredSpoke, []string{"spec.spokeOnly"}) {
+		t.Fatalf("FieldsUncoveredSpoke = %#v, want [spec.spokeOnly]", s.FieldsUncoveredSpoke)
 	}
 }

--- a/internal/controller/xrdconversionconfig_controller.go
+++ b/internal/controller/xrdconversionconfig_controller.go
@@ -264,8 +264,10 @@ func populateSpokeStatuses(cfg *teraskyv1alpha1.XRDConversionConfig, report engi
 	statuses := make([]teraskyv1alpha1.SpokeConversionStatus, 0, len(report.SpokeReports))
 	for _, sr := range report.SpokeReports {
 		s := teraskyv1alpha1.SpokeConversionStatus{
-			Version:  sr.Version,
-			Lossless: teraskyv1alpha1.LosslessVerdict{HubToSpoke: sr.Lossless.HubToSpoke, SpokeToHub: sr.Lossless.SpokeToHub},
+			Version:              sr.Version,
+			Lossless:             teraskyv1alpha1.LosslessVerdict{HubToSpoke: sr.Lossless.HubToSpoke, SpokeToHub: sr.Lossless.SpokeToHub},
+			FieldsUncoveredHub:   sr.Uncovered.UncoveredHub,
+			FieldsUncoveredSpoke: sr.Uncovered.UncoveredSpoke,
 		}
 		for _, d := range sr.Errors {
 			s.Errors = append(s.Errors, d.Message)

--- a/internal/controller/xrdconversionconfig_controller_test.go
+++ b/internal/controller/xrdconversionconfig_controller_test.go
@@ -17,12 +17,14 @@ limitations under the License.
 package controller
 
 import (
+	"reflect"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	teraskyv1alpha1 "github.com/terasky-oss/declarative-conversion-operator/api/v1alpha1"
+	"github.com/terasky-oss/declarative-conversion-operator/pkg/engine"
 )
 
 func xrdWithServedVersions(served ...bool) *unstructured.Unstructured {
@@ -82,5 +84,34 @@ func TestPhasePending_ReportsStaleOnceApplied(t *testing.T) {
 	}
 	if got := phasePending(true); got != teraskyv1alpha1.PhaseStale {
 		t.Fatalf("expected Stale once a config has been Applied before, got %s", got)
+	}
+}
+
+func TestPopulateSpokeStatuses_CopiesUncoveredFields(t *testing.T) {
+	cfg := &teraskyv1alpha1.XRDConversionConfig{}
+	report := engine.AnalyzeReport{
+		SpokeReports: []engine.SpokeReport{{
+			Version:  "v1",
+			Lossless: engine.LosslessVerdict{HubToSpoke: false, SpokeToHub: false},
+			Uncovered: engine.FieldCoverage{
+				UncoveredHub:   []string{"hubOnly"},
+				UncoveredSpoke: []string{"spokeOnly"},
+			},
+			Errors: []engine.Diagnostic{{
+				Severity: engine.SeverityError,
+				Message:  `hub field "hubOnly" is not covered by any rule and has no identical counterpart in the spoke schema`,
+			}},
+		}},
+	}
+	populateSpokeStatuses(cfg, report)
+	if len(cfg.Status.SpokeStatuses) != 1 {
+		t.Fatalf("expected 1 spoke status, got %d", len(cfg.Status.SpokeStatuses))
+	}
+	s := cfg.Status.SpokeStatuses[0]
+	if !reflect.DeepEqual(s.FieldsUncoveredHub, []string{"hubOnly"}) {
+		t.Fatalf("FieldsUncoveredHub = %#v, want [hubOnly]", s.FieldsUncoveredHub)
+	}
+	if !reflect.DeepEqual(s.FieldsUncoveredSpoke, []string{"spokeOnly"}) {
+		t.Fatalf("FieldsUncoveredSpoke = %#v, want [spokeOnly]", s.FieldsUncoveredSpoke)
 	}
 }

--- a/pkg/engine/analyze.go
+++ b/pkg/engine/analyze.go
@@ -79,11 +79,16 @@ func Analyze(in AnalyzeInput) (AnalyzeReport, error) {
 		for _, d := range diags {
 			if d.Severity == SeverityError {
 				sr.Errors = append(sr.Errors, d)
-				if d.FieldPath != "" {
-					sr.Uncovered.UncoveredHub = append(sr.Uncovered.UncoveredHub, d.FieldPath)
-				}
 			} else {
 				sr.Warnings = append(sr.Warnings, d)
+			}
+			// Uncovered leaf paths (Error or Warn policy) feed status
+			// FieldsUncoveredHub / FieldsUncoveredSpoke.
+			switch d.UncoveredSide {
+			case UncoveredSideHub:
+				sr.Uncovered.UncoveredHub = append(sr.Uncovered.UncoveredHub, d.FieldPath)
+			case UncoveredSideSpoke:
+				sr.Uncovered.UncoveredSpoke = append(sr.Uncovered.UncoveredSpoke, d.FieldPath)
 			}
 		}
 		if len(sr.Errors) == 0 {

--- a/pkg/engine/compile.go
+++ b/pkg/engine/compile.go
@@ -791,11 +791,33 @@ func resolveForEach(idx int, p ForEachParams, hub, spoke *extv1.JSONSchemaProps,
 	nestedH2S, nestedS2H, _, nestedDiags, nestedVerdict := resolveAndBuildOps(p.Rules, hubArray.Items.Schema, spokeArray.Items.Schema, policy, depth+1)
 	for _, d := range nestedDiags {
 		d.Message = fmt.Sprintf("rule %d (ForEach) item: %s", idx, d.Message)
+		// Nested analysis uses item-relative FieldPaths; qualify uncovered
+		// paths with the ForEach items path so status FieldsUncovered*
+		// reports the full hub/spoke location (e.g. "readReplicas.name").
+		switch d.UncoveredSide {
+		case UncoveredSideHub:
+			d.FieldPath = qualifyUnderItemsPath(p.HubItemsPath, d.FieldPath)
+		case UncoveredSideSpoke:
+			d.FieldPath = qualifyUnderItemsPath(p.SpokeItemsPath, d.FieldPath)
+		}
 		diags = append(diags, d)
 	}
 	h2s := forEachOp{srcItemsPath: p.HubItemsPath, dstItemsPath: p.SpokeItemsPath, nested: nestedH2S}
 	s2h := forEachOp{srcItemsPath: p.SpokeItemsPath, dstItemsPath: p.HubItemsPath, nested: nestedS2H}
 	return h2s, s2h, nestedVerdict, diags
+}
+
+// qualifyUnderItemsPath prefixes an item-relative uncovered FieldPath with
+// the ForEach items path. Nested ForEach calls qualify at each level so
+// deeply nested paths accumulate the full hub/spoke location.
+func qualifyUnderItemsPath(itemsPath FieldPath, relative string) string {
+	if relative == "" {
+		return itemsPath.String()
+	}
+	if len(itemsPath) == 0 {
+		return relative
+	}
+	return itemsPath.String() + "." + relative
 }
 
 func resolveTypeCoerce(idx int, p TypeCoerceParams, hub, spoke *extv1.JSONSchemaProps, claimedHub, claimedSpoke map[string]bool) (Op, Op, LosslessVerdict, []Diagnostic) {

--- a/pkg/engine/compile.go
+++ b/pkg/engine/compile.go
@@ -247,24 +247,26 @@ func resolveAndBuildOps(rules []Rule, hub, spoke *extv1.JSONSchemaProps, policy 
 			claimedSpoke[key] = true
 			continue
 		}
+		sev := SeverityError
 		if policy == UnmappedFieldPolicyWarn {
-			diags = append(diags, warnf(-1, "hub field %q is not covered by any rule and has no identical counterpart in the spoke schema", key))
+			sev = SeverityWarning
 		} else {
-			diags = append(diags, errorf(-1, "hub field %q is not covered by any rule and has no identical counterpart in the spoke schema", key))
 			verdict.HubToSpoke = false
 		}
+		diags = append(diags, uncoveredFieldDiag(sev, UncoveredSideHub, key))
 	}
 	for _, sl := range spokeLeaves {
 		key := sl.Path.String()
 		if claimedSpoke[key] {
 			continue
 		}
+		sev := SeverityError
 		if policy == UnmappedFieldPolicyWarn {
-			diags = append(diags, warnf(-1, "spoke field %q is not covered by any rule and has no identical counterpart in the hub schema", key))
+			sev = SeverityWarning
 		} else {
-			diags = append(diags, errorf(-1, "spoke field %q is not covered by any rule and has no identical counterpart in the hub schema", key))
 			verdict.SpokeToHub = false
 		}
+		diags = append(diags, uncoveredFieldDiag(sev, UncoveredSideSpoke, key))
 	}
 
 	// A field the schema never declares at all (on either side) never

--- a/pkg/engine/compile_test.go
+++ b/pkg/engine/compile_test.go
@@ -970,3 +970,76 @@ func TestAnalyze_KeepsLastGoodPlanShape(t *testing.T) {
 		t.Fatalf("expected HasErrors() to be true")
 	}
 }
+
+func TestAnalyze_PopulatesUncoveredHubAndSpoke(t *testing.T) {
+	hubSchema := objSchema(map[string]extv1.JSONSchemaProps{
+		"shared":  strSchema(),
+		"hubOnly": strSchema(),
+	})
+	spokeSchema := objSchema(map[string]extv1.JSONSchemaProps{
+		"shared":    strSchema(),
+		"spokeOnly": strSchema(),
+	})
+	src := fakeSource{gen: 1, versions: []VersionSchema{
+		{Name: "v2", Schema: &hubSchema, Served: true, Storage: true},
+		{Name: "v1", Schema: &spokeSchema, Served: true},
+	}}
+
+	report, err := Analyze(AnalyzeInput{Source: src, HubVersion: "v2", Spokes: []RuleSet{{SpokeVersion: "v1"}}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	sr := report.SpokeReports[0]
+	if !reflect.DeepEqual(sr.Uncovered.UncoveredHub, []string{"hubOnly"}) {
+		t.Fatalf("UncoveredHub = %#v, want [hubOnly]", sr.Uncovered.UncoveredHub)
+	}
+	if !reflect.DeepEqual(sr.Uncovered.UncoveredSpoke, []string{"spokeOnly"}) {
+		t.Fatalf("UncoveredSpoke = %#v, want [spokeOnly]", sr.Uncovered.UncoveredSpoke)
+	}
+	if len(sr.Errors) == 0 {
+		t.Fatalf("expected uncovered-field errors under default Error policy")
+	}
+}
+
+func TestAnalyze_UncoveredUnderWarnPolicy(t *testing.T) {
+	hubSchema := objSchema(map[string]extv1.JSONSchemaProps{
+		"shared":  strSchema(),
+		"hubOnly": strSchema(),
+	})
+	spokeSchema := objSchema(map[string]extv1.JSONSchemaProps{
+		"shared":    strSchema(),
+		"spokeOnly": strSchema(),
+	})
+	src := fakeSource{gen: 1, versions: []VersionSchema{
+		{Name: "v2", Schema: &hubSchema, Served: true, Storage: true},
+		{Name: "v1", Schema: &spokeSchema, Served: true},
+	}}
+
+	report, err := Analyze(AnalyzeInput{
+		Source:     src,
+		HubVersion: "v2",
+		Spokes: []RuleSet{{
+			SpokeVersion:        "v1",
+			UnmappedFieldPolicy: UnmappedFieldPolicyWarn,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	sr := report.SpokeReports[0]
+	if len(sr.Errors) != 0 {
+		t.Fatalf("expected no errors under Warn policy, got: %v", sr.Errors)
+	}
+	if len(sr.Warnings) == 0 {
+		t.Fatalf("expected uncovered-field warnings under Warn policy")
+	}
+	if !reflect.DeepEqual(sr.Uncovered.UncoveredHub, []string{"hubOnly"}) {
+		t.Fatalf("UncoveredHub = %#v, want [hubOnly] (Warn policy must still populate coverage)", sr.Uncovered.UncoveredHub)
+	}
+	if !reflect.DeepEqual(sr.Uncovered.UncoveredSpoke, []string{"spokeOnly"}) {
+		t.Fatalf("UncoveredSpoke = %#v, want [spokeOnly] (Warn policy must still populate coverage)", sr.Uncovered.UncoveredSpoke)
+	}
+	if sr.CompiledPlan == nil {
+		t.Fatalf("expected a compiled plan under Warn policy (warnings only)")
+	}
+}

--- a/pkg/engine/compile_test.go
+++ b/pkg/engine/compile_test.go
@@ -1001,6 +1001,53 @@ func TestAnalyze_PopulatesUncoveredHubAndSpoke(t *testing.T) {
 	}
 }
 
+func TestAnalyze_ForEachUncoveredUsesFullPath(t *testing.T) {
+	hubSchema := objSchema(map[string]extv1.JSONSchemaProps{
+		"readReplicas": arrSchema(objSchema(map[string]extv1.JSONSchemaProps{
+			"region":  strSchema(),
+			"hubOnly": strSchema(),
+		}), nil),
+	})
+	spokeSchema := objSchema(map[string]extv1.JSONSchemaProps{
+		"readReplicas": arrSchema(objSchema(map[string]extv1.JSONSchemaProps{
+			"zone":      strSchema(),
+			"spokeOnly": strSchema(),
+		}), nil),
+	})
+	src := fakeSource{gen: 1, versions: []VersionSchema{
+		{Name: "v2", Schema: &hubSchema, Served: true, Storage: true},
+		{Name: "v1", Schema: &spokeSchema, Served: true},
+	}}
+
+	report, err := Analyze(AnalyzeInput{
+		Source:     src,
+		HubVersion: "v2",
+		Spokes: []RuleSet{{
+			SpokeVersion: "v1",
+			Rules: []Rule{{
+				Strategy: StrategyForEach,
+				Params: ForEachParams{
+					HubItemsPath: ParsePath("readReplicas"), SpokeItemsPath: ParsePath("readReplicas"),
+					Rules: []Rule{{
+						Strategy: StrategyFieldRename,
+						Params:   FieldRenameParams{HubPath: ParsePath("region"), SpokePath: ParsePath("zone")},
+					}},
+				},
+			}},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	sr := report.SpokeReports[0]
+	if !reflect.DeepEqual(sr.Uncovered.UncoveredHub, []string{"readReplicas.hubOnly"}) {
+		t.Fatalf("UncoveredHub = %#v, want [readReplicas.hubOnly]", sr.Uncovered.UncoveredHub)
+	}
+	if !reflect.DeepEqual(sr.Uncovered.UncoveredSpoke, []string{"readReplicas.spokeOnly"}) {
+		t.Fatalf("UncoveredSpoke = %#v, want [readReplicas.spokeOnly]", sr.Uncovered.UncoveredSpoke)
+	}
+}
+
 func TestAnalyze_UncoveredUnderWarnPolicy(t *testing.T) {
 	hubSchema := objSchema(map[string]extv1.JSONSchemaProps{
 		"shared":  strSchema(),

--- a/pkg/engine/diagnostics.go
+++ b/pkg/engine/diagnostics.go
@@ -26,12 +26,25 @@ const (
 	SeverityWarning Severity = "Warning"
 )
 
+// UncoveredSide tags leftover uncovered-field diagnostics so Analyze can
+// populate FieldCoverage without parsing message text. Empty for every
+// other diagnostic.
+type UncoveredSide string
+
+const (
+	UncoveredSideHub   UncoveredSide = "hub"
+	UncoveredSideSpoke UncoveredSide = "spoke"
+)
+
 // Diagnostic is one issue found while analyzing or compiling a RuleSet.
 type Diagnostic struct {
 	Severity  Severity
 	Message   string
 	RuleIndex int    // -1 if not associated with a specific rule
 	FieldPath string // empty if not associated with a specific field
+	// UncoveredSide is set only for leftover uncovered-leaf diagnostics
+	// (hub or spoke); empty otherwise.
+	UncoveredSide UncoveredSide
 }
 
 func errorf(ruleIndex int, format string, args ...any) Diagnostic {
@@ -40,6 +53,29 @@ func errorf(ruleIndex int, format string, args ...any) Diagnostic {
 
 func warnf(ruleIndex int, format string, args ...any) Diagnostic {
 	return Diagnostic{Severity: SeverityWarning, Message: fmt.Sprintf(format, args...), RuleIndex: ruleIndex}
+}
+
+// uncoveredFieldDiag reports a leaf path left unclaimed by any rule (and
+// without an identical counterpart on the other side). FieldPath and
+// UncoveredSide are always set so Analyze can populate FieldCoverage for
+// both Error and Warn unmapped-field policies.
+func uncoveredFieldDiag(severity Severity, side UncoveredSide, path string) Diagnostic {
+	var msg string
+	switch side {
+	case UncoveredSideHub:
+		msg = fmt.Sprintf("hub field %q is not covered by any rule and has no identical counterpart in the spoke schema", path)
+	case UncoveredSideSpoke:
+		msg = fmt.Sprintf("spoke field %q is not covered by any rule and has no identical counterpart in the hub schema", path)
+	default:
+		msg = fmt.Sprintf("field %q is not covered by any rule", path)
+	}
+	return Diagnostic{
+		Severity:      severity,
+		Message:       msg,
+		RuleIndex:     -1,
+		FieldPath:     path,
+		UncoveredSide: side,
+	}
 }
 
 // LosslessVerdict records whether a mapping is lossless in each direction


### PR DESCRIPTION
## Summary
- Tag leftover uncovered-field compile diagnostics with `FieldPath` + `UncoveredSide`, and fix Analyze so hub vs spoke uncovered leaves populate `UncoveredHub` / `UncoveredSpoke` (including Warn policy warnings).
- Copy those slices into `status.spokeStatuses[].fieldsUncoveredHub` / `fieldsUncoveredSpoke` in both XRD and CRD controllers.
- Add engine Analyze unit tests and focused `populateSpokeStatuses` / `populateCRDSpokeStatuses` controller tests.

Closes #7

## Test plan
- [x] `go test ./pkg/engine/... ./internal/controller/... -race -count=1`
- [x] `make test`
- [x] `make test-e2e`
- [ ] Confirm on a config with uncovered leaves that `status.spokeStatuses[].fieldsUncovered*` lists the actual hub/spoke paths under both Error and Warn `unmappedFieldPolicy`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Conversion analysis now identifies uncovered fields on both hub and spoke sides.
  * Status results include uncovered field paths alongside version and losslessness information.
  * Diagnostics indicate which conversion side contains each uncovered field.
  * Warning policies preserve coverage details without marking conversion as lossy.

* **Bug Fixes**
  * Uncovered-field diagnostics are now reported consistently for both errors and warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->