### PR TITLE
0.4: set ConditionStale=True on KeepServingStale drift

### DIFF
--- a/internal/controller/crdconversionconfig_controller.go
+++ b/internal/controller/crdconversionconfig_controller.go
@@ -99,7 +99,11 @@ func (r *CRDConversionConfigReconciler) Reconcile(ctx context.Context, req recon
 }
 
 func (r *CRDConversionConfigReconciler) reconcileNormal(ctx context.Context, cfg *teraskyv1alpha1.CRDConversionConfig) (ctrl.Result, error) {
-	wasApplied := cfg.Status.Phase == teraskyv1alpha1.PhaseApplied
+	// PhaseStale means a prior apply still stands (KeepServingStale /
+	// health-gate hold). Treat it like Applied so a later reconcile does
+	// not demote persistent drift to Invalid or drop ConditionStale.
+	wasApplied := cfg.Status.Phase == teraskyv1alpha1.PhaseApplied ||
+		cfg.Status.Phase == teraskyv1alpha1.PhaseStale
 	orig := cfg.DeepCopy()
 
 	// Step 1: fetch the target CRD.

--- a/internal/controller/crdconversionconfig_controller.go
+++ b/internal/controller/crdconversionconfig_controller.go
@@ -138,12 +138,14 @@ func (r *CRDConversionConfigReconciler) reconcileNormal(ctx context.Context, cfg
 				logger.Error(err, "failed to revert CRD after drift under FailClosed policy")
 			}
 			cfg.Status.Phase = teraskyv1alpha1.PhaseFailed
+			meta.RemoveStatusCondition(&cfg.Status.Conditions, teraskyv1alpha1.ConditionStale)
 			msg = "schema drift invalidated a previously-applied config; reverted to strategy=None per driftPolicy=FailClosed"
 		} else if wasApplied {
-			cfg.Status.Phase = teraskyv1alpha1.PhaseStale
 			msg = "schema drift invalidated this config, but the previously-applied webhook configuration is left untouched (driftPolicy=KeepServingStale); fix the config or the CRD to clear this"
+			setPhaseStale(&cfg.Status.Conditions, &cfg.Status.Phase, "SchemaDrift", msg)
 		} else {
 			cfg.Status.Phase = teraskyv1alpha1.PhaseInvalid
+			meta.RemoveStatusCondition(&cfg.Status.Conditions, teraskyv1alpha1.ConditionStale)
 		}
 		meta.SetStatusCondition(&cfg.Status.Conditions, metav1.Condition{
 			Type: teraskyv1alpha1.ConditionValidated, Status: metav1.ConditionFalse, Reason: "ValidationFailed", Message: msg,
@@ -170,10 +172,11 @@ func (r *CRDConversionConfigReconciler) reconcileNormal(ctx context.Context, cfg
 
 	// Step 5: CRD health gate.
 	if !crdadapter.Established(&crd) {
+		msg := "target CustomResourceDefinition is not yet Established"
 		meta.SetStatusCondition(&cfg.Status.Conditions, metav1.Condition{
-			Type: teraskyv1alpha1.ConditionCRDHealthy, Status: metav1.ConditionFalse, Reason: "NotEstablished", Message: "target CustomResourceDefinition is not yet Established",
+			Type: teraskyv1alpha1.ConditionCRDHealthy, Status: metav1.ConditionFalse, Reason: "NotEstablished", Message: msg,
 		})
-		cfg.Status.Phase = phasePending(wasApplied)
+		setPhasePendingOrStale(&cfg.Status.Conditions, &cfg.Status.Phase, wasApplied, "NotEstablished", msg)
 		return ctrl.Result{RequeueAfter: 15 * time.Second}, r.patchStatus(ctx, orig, cfg)
 	}
 	meta.SetStatusCondition(&cfg.Status.Conditions, metav1.Condition{
@@ -186,10 +189,11 @@ func (r *CRDConversionConfigReconciler) reconcileNormal(ctx context.Context, cfg
 		return ctrl.Result{}, fmt.Errorf("getting assigned ConversionWebhookServer %q: %w", serverName, err)
 	}
 	if !isServerReady(&server) {
+		msg := fmt.Sprintf("ConversionWebhookServer %q is not yet Available", serverName)
 		meta.SetStatusCondition(&cfg.Status.Conditions, metav1.Condition{
-			Type: teraskyv1alpha1.ConditionWebhookServerReady, Status: metav1.ConditionFalse, Reason: "ServerNotReady", Message: fmt.Sprintf("ConversionWebhookServer %q is not yet Available", serverName),
+			Type: teraskyv1alpha1.ConditionWebhookServerReady, Status: metav1.ConditionFalse, Reason: "ServerNotReady", Message: msg,
 		})
-		cfg.Status.Phase = phasePending(wasApplied)
+		setPhasePendingOrStale(&cfg.Status.Conditions, &cfg.Status.Phase, wasApplied, "ServerNotReady", msg)
 		return ctrl.Result{RequeueAfter: 15 * time.Second}, r.patchStatus(ctx, orig, cfg)
 	}
 	meta.SetStatusCondition(&cfg.Status.Conditions, metav1.Condition{
@@ -237,9 +241,10 @@ func (r *CRDConversionConfigReconciler) reconcileNormal(ctx context.Context, cfg
 
 func (r *CRDConversionConfigReconciler) setInvalid(cfg *teraskyv1alpha1.CRDConversionConfig, wasApplied bool, msg string) {
 	if wasApplied {
-		cfg.Status.Phase = teraskyv1alpha1.PhaseStale
+		setPhaseStale(&cfg.Status.Conditions, &cfg.Status.Phase, "PostApplyInvalid", msg)
 	} else {
 		cfg.Status.Phase = teraskyv1alpha1.PhaseInvalid
+		meta.RemoveStatusCondition(&cfg.Status.Conditions, teraskyv1alpha1.ConditionStale)
 	}
 	cfg.Status.Message = msg
 	meta.SetStatusCondition(&cfg.Status.Conditions, metav1.Condition{

--- a/internal/controller/crdconversionconfig_controller_test.go
+++ b/internal/controller/crdconversionconfig_controller_test.go
@@ -189,6 +189,19 @@ func TestCRDReconcile_Drift_KeepServingStale(t *testing.T) {
 		t.Fatalf("expected condition Stale=True alongside phase Stale, got %+v", got.Status.Conditions)
 	}
 
+	// Reconcile again while drift remains: PhaseStale must keep wasApplied
+	// semantics so we stay Stale instead of demoting to Invalid.
+	if _, err := reconcileCRD(t, r, "cfg"); err != nil {
+		t.Fatalf("unexpected error on second drift reconcile: %v", err)
+	}
+	got = getCRDConfig(t, r, "cfg")
+	if got.Status.Phase != teraskyv1alpha1.PhaseStale {
+		t.Fatalf("expected phase to remain Stale on second reconcile, got %q", got.Status.Phase)
+	}
+	if !meta.IsStatusConditionTrue(got.Status.Conditions, teraskyv1alpha1.ConditionStale) {
+		t.Fatalf("expected ConditionStale=True to remain on second reconcile, got %+v", got.Status.Conditions)
+	}
+
 	live = getCRDConfig(t, r, "cfg")
 	live.Spec.Spokes[0].Rules[0].FieldRename.HubPath = "spec.size"
 	if err := r.Update(context.Background(), live); err != nil {

--- a/internal/controller/crdconversionconfig_controller_test.go
+++ b/internal/controller/crdconversionconfig_controller_test.go
@@ -161,6 +161,51 @@ func TestCRDReconcile_Drift_FailClosed_RevertsAndFails(t *testing.T) {
 	}
 }
 
+func TestCRDReconcile_Drift_KeepServingStale(t *testing.T) {
+	crd := establishedCRD("foos.example.org")
+	cfg := renameRuleCRDConfig("cfg", "foos.example.org")
+	cfg.Spec.DriftPolicy = teraskyv1alpha1.DriftPolicyKeepServingStale
+	cfg.Status.Phase = teraskyv1alpha1.PhaseApplied
+	controllerutil.AddFinalizer(cfg, teraskyv1alpha1.CRDConversionConfigFinalizer)
+	server, secret := readyServer("srv")
+
+	c := newFakeClient(crd, cfg, server, secret).Build()
+	r := &CRDConversionConfigReconciler{Client: c, DefaultServerNamespace: "operator-ns"}
+
+	live := getCRDConfig(t, r, "cfg")
+	live.Spec.Spokes[0].Rules[0].FieldRename.HubPath = "spec.doesNotExist"
+	if err := r.Update(context.Background(), live); err != nil {
+		t.Fatalf("updating config: %v", err)
+	}
+
+	if _, err := reconcileCRD(t, r, "cfg"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := getCRDConfig(t, r, "cfg")
+	if got.Status.Phase != teraskyv1alpha1.PhaseStale {
+		t.Fatalf("expected phase Stale under KeepServingStale drift, got %q", got.Status.Phase)
+	}
+	if !meta.IsStatusConditionTrue(got.Status.Conditions, teraskyv1alpha1.ConditionStale) {
+		t.Fatalf("expected condition Stale=True alongside phase Stale, got %+v", got.Status.Conditions)
+	}
+
+	live = getCRDConfig(t, r, "cfg")
+	live.Spec.Spokes[0].Rules[0].FieldRename.HubPath = "spec.size"
+	if err := r.Update(context.Background(), live); err != nil {
+		t.Fatalf("restoring valid rule: %v", err)
+	}
+	if _, err := reconcileCRD(t, r, "cfg"); err != nil {
+		t.Fatalf("unexpected error after resolving drift: %v", err)
+	}
+	got = getCRDConfig(t, r, "cfg")
+	if got.Status.Phase != teraskyv1alpha1.PhaseApplied {
+		t.Fatalf("expected phase Applied after resolving drift, got %q (message: %s)", got.Status.Phase, got.Status.Message)
+	}
+	if cond := meta.FindStatusCondition(got.Status.Conditions, teraskyv1alpha1.ConditionStale); cond != nil {
+		t.Fatalf("expected ConditionStale to be cleared after drift resolves, got %+v", cond)
+	}
+}
+
 func TestCRDReconcile_Delete_BlockedByMultipleServedVersions(t *testing.T) {
 	crd := establishedCRD("foos.example.org") // v1 and v2, both served
 	cfg := renameRuleCRDConfig("cfg", "foos.example.org")

--- a/internal/controller/xrdconversionconfig_controller.go
+++ b/internal/controller/xrdconversionconfig_controller.go
@@ -95,7 +95,11 @@ func (r *XRDConversionConfigReconciler) Reconcile(ctx context.Context, req recon
 }
 
 func (r *XRDConversionConfigReconciler) reconcileNormal(ctx context.Context, cfg *teraskyv1alpha1.XRDConversionConfig) (ctrl.Result, error) {
-	wasApplied := cfg.Status.Phase == teraskyv1alpha1.PhaseApplied
+	// PhaseStale means a prior apply still stands (KeepServingStale /
+	// health-gate hold). Treat it like Applied so a later reconcile does
+	// not demote persistent drift to Invalid or drop ConditionStale.
+	wasApplied := cfg.Status.Phase == teraskyv1alpha1.PhaseApplied ||
+		cfg.Status.Phase == teraskyv1alpha1.PhaseStale
 	orig := cfg.DeepCopy()
 
 	// Step 1: fetch the target XRD.

--- a/internal/controller/xrdconversionconfig_controller.go
+++ b/internal/controller/xrdconversionconfig_controller.go
@@ -135,15 +135,17 @@ func (r *XRDConversionConfigReconciler) reconcileNormal(ctx context.Context, cfg
 				logger.Error(err, "failed to revert XRD after drift under FailClosed policy")
 			}
 			cfg.Status.Phase = teraskyv1alpha1.PhaseFailed
+			meta.RemoveStatusCondition(&cfg.Status.Conditions, teraskyv1alpha1.ConditionStale)
 			msg = "schema drift invalidated a previously-applied config; reverted to strategy=None per driftPolicy=FailClosed"
 		} else if wasApplied {
 			// Conservative default: keep serving the last known-good
 			// compiled plan (unchanged on the XRD) and mark Stale rather
 			// than risk an outage by touching a working conversion setup.
-			cfg.Status.Phase = teraskyv1alpha1.PhaseStale
 			msg = "schema drift invalidated this config, but the previously-applied webhook configuration is left untouched (driftPolicy=KeepServingStale); fix the config or the XRD to clear this"
+			setPhaseStale(&cfg.Status.Conditions, &cfg.Status.Phase, "SchemaDrift", msg)
 		} else {
 			cfg.Status.Phase = teraskyv1alpha1.PhaseInvalid
+			meta.RemoveStatusCondition(&cfg.Status.Conditions, teraskyv1alpha1.ConditionStale)
 		}
 		meta.SetStatusCondition(&cfg.Status.Conditions, metav1.Condition{
 			Type: teraskyv1alpha1.ConditionValidated, Status: metav1.ConditionFalse, Reason: "ValidationFailed", Message: msg,
@@ -170,10 +172,11 @@ func (r *XRDConversionConfigReconciler) reconcileNormal(ctx context.Context, cfg
 
 	// Step 5: XRD health gate.
 	if !xrdadapter.Established(xrd) {
+		msg := "target XRD is not yet Established"
 		meta.SetStatusCondition(&cfg.Status.Conditions, metav1.Condition{
-			Type: teraskyv1alpha1.ConditionXRDHealthy, Status: metav1.ConditionFalse, Reason: "NotEstablished", Message: "target XRD is not yet Established",
+			Type: teraskyv1alpha1.ConditionXRDHealthy, Status: metav1.ConditionFalse, Reason: "NotEstablished", Message: msg,
 		})
-		cfg.Status.Phase = phasePending(wasApplied)
+		setPhasePendingOrStale(&cfg.Status.Conditions, &cfg.Status.Phase, wasApplied, "NotEstablished", msg)
 		return ctrl.Result{RequeueAfter: 15 * time.Second}, r.patchStatus(ctx, orig, cfg)
 	}
 	meta.SetStatusCondition(&cfg.Status.Conditions, metav1.Condition{
@@ -186,10 +189,11 @@ func (r *XRDConversionConfigReconciler) reconcileNormal(ctx context.Context, cfg
 		return ctrl.Result{}, fmt.Errorf("getting assigned ConversionWebhookServer %q: %w", serverName, err)
 	}
 	if !isServerReady(&server) {
+		msg := fmt.Sprintf("ConversionWebhookServer %q is not yet Available", serverName)
 		meta.SetStatusCondition(&cfg.Status.Conditions, metav1.Condition{
-			Type: teraskyv1alpha1.ConditionWebhookServerReady, Status: metav1.ConditionFalse, Reason: "ServerNotReady", Message: fmt.Sprintf("ConversionWebhookServer %q is not yet Available", serverName),
+			Type: teraskyv1alpha1.ConditionWebhookServerReady, Status: metav1.ConditionFalse, Reason: "ServerNotReady", Message: msg,
 		})
-		cfg.Status.Phase = phasePending(wasApplied)
+		setPhasePendingOrStale(&cfg.Status.Conditions, &cfg.Status.Phase, wasApplied, "ServerNotReady", msg)
 		return ctrl.Result{RequeueAfter: 15 * time.Second}, r.patchStatus(ctx, orig, cfg)
 	}
 	meta.SetStatusCondition(&cfg.Status.Conditions, metav1.Condition{
@@ -248,11 +252,35 @@ func phasePending(wasApplied bool) string {
 	return teraskyv1alpha1.PhasePending
 }
 
+// setPhaseStale sets Phase=Stale and ConditionStale=True so monitors that
+// watch status.conditions see the same signal as status.phase.
+func setPhaseStale(conditions *[]metav1.Condition, phase *string, reason, message string) {
+	*phase = teraskyv1alpha1.PhaseStale
+	meta.SetStatusCondition(conditions, metav1.Condition{
+		Type:    teraskyv1alpha1.ConditionStale,
+		Status:  metav1.ConditionTrue,
+		Reason:  reason,
+		Message: message,
+	})
+}
+
+// setPhasePendingOrStale sets Pending for never-applied configs, or Stale
+// (phase + condition) when a previously-applied config is waiting on a gate.
+func setPhasePendingOrStale(conditions *[]metav1.Condition, phase *string, wasApplied bool, reason, message string) {
+	if wasApplied {
+		setPhaseStale(conditions, phase, reason, message)
+		return
+	}
+	*phase = teraskyv1alpha1.PhasePending
+	meta.RemoveStatusCondition(conditions, teraskyv1alpha1.ConditionStale)
+}
+
 func (r *XRDConversionConfigReconciler) setInvalid(cfg *teraskyv1alpha1.XRDConversionConfig, wasApplied bool, msg string) {
 	if wasApplied {
-		cfg.Status.Phase = teraskyv1alpha1.PhaseStale
+		setPhaseStale(&cfg.Status.Conditions, &cfg.Status.Phase, "PostApplyInvalid", msg)
 	} else {
 		cfg.Status.Phase = teraskyv1alpha1.PhaseInvalid
+		meta.RemoveStatusCondition(&cfg.Status.Conditions, teraskyv1alpha1.ConditionStale)
 	}
 	cfg.Status.Message = msg
 	meta.SetStatusCondition(&cfg.Status.Conditions, metav1.Condition{

--- a/internal/controller/xrdconversionconfig_controller_reconcile_test.go
+++ b/internal/controller/xrdconversionconfig_controller_reconcile_test.go
@@ -274,6 +274,26 @@ func TestXRDReconcile_Drift_KeepServingStale(t *testing.T) {
 	if got.Status.Phase != teraskyv1alpha1.PhaseStale {
 		t.Fatalf("expected phase Stale under KeepServingStale drift, got %q", got.Status.Phase)
 	}
+	if !meta.IsStatusConditionTrue(got.Status.Conditions, teraskyv1alpha1.ConditionStale) {
+		t.Fatalf("expected condition Stale=True alongside phase Stale, got %+v", got.Status.Conditions)
+	}
+
+	// Resolve the drift: restore a valid hub path and re-reconcile.
+	live = getXRDConfig(t, r, "cfg")
+	live.Spec.Spokes[0].Rules[0].FieldRename.HubPath = "spec.size"
+	if err := r.Update(context.Background(), live); err != nil {
+		t.Fatalf("restoring valid rule: %v", err)
+	}
+	if _, err := reconcileXRD(t, r, "cfg"); err != nil {
+		t.Fatalf("unexpected error after resolving drift: %v", err)
+	}
+	got = getXRDConfig(t, r, "cfg")
+	if got.Status.Phase != teraskyv1alpha1.PhaseApplied {
+		t.Fatalf("expected phase Applied after resolving drift, got %q (message: %s)", got.Status.Phase, got.Status.Message)
+	}
+	if cond := meta.FindStatusCondition(got.Status.Conditions, teraskyv1alpha1.ConditionStale); cond != nil {
+		t.Fatalf("expected ConditionStale to be cleared after drift resolves, got %+v", cond)
+	}
 }
 
 func TestXRDReconcile_Delete_BlockedByMultipleServedVersions(t *testing.T) {

--- a/internal/controller/xrdconversionconfig_controller_reconcile_test.go
+++ b/internal/controller/xrdconversionconfig_controller_reconcile_test.go
@@ -278,6 +278,19 @@ func TestXRDReconcile_Drift_KeepServingStale(t *testing.T) {
 		t.Fatalf("expected condition Stale=True alongside phase Stale, got %+v", got.Status.Conditions)
 	}
 
+	// Reconcile again while drift remains: PhaseStale must keep wasApplied
+	// semantics so we stay Stale instead of demoting to Invalid.
+	if _, err := reconcileXRD(t, r, "cfg"); err != nil {
+		t.Fatalf("unexpected error on second drift reconcile: %v", err)
+	}
+	got = getXRDConfig(t, r, "cfg")
+	if got.Status.Phase != teraskyv1alpha1.PhaseStale {
+		t.Fatalf("expected phase to remain Stale on second reconcile, got %q", got.Status.Phase)
+	}
+	if !meta.IsStatusConditionTrue(got.Status.Conditions, teraskyv1alpha1.ConditionStale) {
+		t.Fatalf("expected ConditionStale=True to remain on second reconcile, got %+v", got.Status.Conditions)
+	}
+
 	// Resolve the drift: restore a valid hub path and re-reconcile.
 	live = getXRDConfig(t, r, "cfg")
 	live.Spec.Spokes[0].Rules[0].FieldRename.HubPath = "spec.size"


### PR DESCRIPTION
## Summary
- Set `ConditionStale=True` whenever `Phase` becomes `PhaseStale` (KeepServingStale drift, post-apply invalid, and pending gates after apply) in both XRD and CRD controllers, so monitors watching `status.conditions` see the same signal as `status.phase`.
- Clear/remove `ConditionStale` when leaving Stale (Applied path already did; also clear on Failed/Invalid/Pending).
- Extend reconcile tests for KeepServingStale drift → Stale condition True, then resolve drift → condition cleared.

Closes #9

## Test plan
- [x] `make test`
- [x] `make test-e2e`
- [x] `TestXRDReconcile_Drift_KeepServingStale` asserts `Stale=True` + phase Stale, then clears after resolve
- [x] `TestCRDReconcile_Drift_KeepServingStale` mirrors the same acceptance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversion configuration status reporting when schemas, resources, or webhook services become invalid or unavailable.
  * Applied configurations now clearly show a **Stale** condition while continuing to serve the last valid configuration when configured to do so.
  * Restoring a valid configuration returns its status to **Applied** and clears the stale condition.
  * Improved handling of pending and invalid configurations to prevent outdated status conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->