### PR TITLE
0.5: honest status when FailClosed revert fails

### DIFF
--- a/api/v1alpha1/xrdconversionconfig_types.go
+++ b/api/v1alpha1/xrdconversionconfig_types.go
@@ -545,6 +545,10 @@ const (
 	ConditionApplied            = "Applied"
 	ConditionStale              = "Stale"
 	ConditionDeletionBlocked    = "DeletionBlocked"
+
+	// ConditionApplied reasons used by FailClosed drift handling.
+	ReasonReverted     = "Reverted"
+	ReasonRevertFailed = "RevertFailed"
 )
 
 // Phase constants for XRDConversionConfigStatus.Phase.

--- a/internal/controller/crdconversionconfig_controller.go
+++ b/internal/controller/crdconversionconfig_controller.go
@@ -150,14 +150,14 @@ func (r *CRDConversionConfigReconciler) reconcileNormal(ctx context.Context, cfg
 				meta.RemoveStatusCondition(&cfg.Status.Conditions, teraskyv1alpha1.ConditionStale)
 				msg = fmt.Sprintf("schema drift invalidated a previously-applied config; failed to revert to strategy=None per driftPolicy=FailClosed: %v", err)
 				meta.SetStatusCondition(&cfg.Status.Conditions, metav1.Condition{
-					Type: teraskyv1alpha1.ConditionApplied, Status: metav1.ConditionFalse, Reason: "RevertFailed", Message: msg,
+					Type: teraskyv1alpha1.ConditionApplied, Status: metav1.ConditionFalse, Reason: teraskyv1alpha1.ReasonRevertFailed, Message: msg,
 				})
 			} else {
 				cfg.Status.Phase = teraskyv1alpha1.PhaseFailed
 				meta.RemoveStatusCondition(&cfg.Status.Conditions, teraskyv1alpha1.ConditionStale)
 				msg = "schema drift invalidated a previously-applied config; reverted to strategy=None per driftPolicy=FailClosed"
 				meta.SetStatusCondition(&cfg.Status.Conditions, metav1.Condition{
-					Type: teraskyv1alpha1.ConditionApplied, Status: metav1.ConditionFalse, Reason: "Reverted", Message: msg,
+					Type: teraskyv1alpha1.ConditionApplied, Status: metav1.ConditionFalse, Reason: teraskyv1alpha1.ReasonReverted, Message: msg,
 				})
 			}
 		} else if wasApplied {

--- a/internal/controller/crdconversionconfig_controller.go
+++ b/internal/controller/crdconversionconfig_controller.go
@@ -136,14 +136,30 @@ func (r *CRDConversionConfigReconciler) reconcileNormal(ctx context.Context, cfg
 
 	if report.HasErrors() {
 		msg := "one or more spoke versions failed validation; see status.spokeStatuses for details"
-		if wasApplied && cfg.Spec.DriftPolicy == teraskyv1alpha1.DriftPolicyFailClosed {
+		var revertErr error
+		if failClosedShouldRevert(cfg.Spec.DriftPolicy, cfg.Status.Phase, cfg.Status.Conditions) {
 			if err := r.revertCRD(ctx, cfg.Spec.TargetCRD.Name); err != nil {
+				// Do not claim a successful revert: the CRD may still be
+				// serving webhook conversion. Keep Phase=Failed with an
+				// honest message, surface RevertFailed on ConditionApplied,
+				// and return the error so reconcile requeues with backoff.
+				revertErr = err
 				logger := log.FromContext(ctx)
 				logger.Error(err, "failed to revert CRD after drift under FailClosed policy")
+				cfg.Status.Phase = teraskyv1alpha1.PhaseFailed
+				meta.RemoveStatusCondition(&cfg.Status.Conditions, teraskyv1alpha1.ConditionStale)
+				msg = fmt.Sprintf("schema drift invalidated a previously-applied config; failed to revert to strategy=None per driftPolicy=FailClosed: %v", err)
+				meta.SetStatusCondition(&cfg.Status.Conditions, metav1.Condition{
+					Type: teraskyv1alpha1.ConditionApplied, Status: metav1.ConditionFalse, Reason: "RevertFailed", Message: msg,
+				})
+			} else {
+				cfg.Status.Phase = teraskyv1alpha1.PhaseFailed
+				meta.RemoveStatusCondition(&cfg.Status.Conditions, teraskyv1alpha1.ConditionStale)
+				msg = "schema drift invalidated a previously-applied config; reverted to strategy=None per driftPolicy=FailClosed"
+				meta.SetStatusCondition(&cfg.Status.Conditions, metav1.Condition{
+					Type: teraskyv1alpha1.ConditionApplied, Status: metav1.ConditionFalse, Reason: "Reverted", Message: msg,
+				})
 			}
-			cfg.Status.Phase = teraskyv1alpha1.PhaseFailed
-			meta.RemoveStatusCondition(&cfg.Status.Conditions, teraskyv1alpha1.ConditionStale)
-			msg = "schema drift invalidated a previously-applied config; reverted to strategy=None per driftPolicy=FailClosed"
 		} else if wasApplied {
 			msg = "schema drift invalidated this config, but the previously-applied webhook configuration is left untouched (driftPolicy=KeepServingStale); fix the config or the CRD to clear this"
 			setPhaseStale(&cfg.Status.Conditions, &cfg.Status.Phase, "SchemaDrift", msg)
@@ -155,7 +171,13 @@ func (r *CRDConversionConfigReconciler) reconcileNormal(ctx context.Context, cfg
 			Type: teraskyv1alpha1.ConditionValidated, Status: metav1.ConditionFalse, Reason: "ValidationFailed", Message: msg,
 		})
 		cfg.Status.Message = msg
-		return ctrl.Result{}, r.patchStatus(ctx, orig, cfg)
+		if err := r.patchStatus(ctx, orig, cfg); err != nil {
+			return ctrl.Result{}, err
+		}
+		if revertErr != nil {
+			return ctrl.Result{}, fmt.Errorf("reverting CRD after FailClosed drift: %w", revertErr)
+		}
+		return ctrl.Result{}, nil
 	}
 
 	meta.SetStatusCondition(&cfg.Status.Conditions, metav1.Condition{

--- a/internal/controller/crdconversionconfig_controller_test.go
+++ b/internal/controller/crdconversionconfig_controller_test.go
@@ -18,13 +18,18 @@ package controller
 
 import (
 	"context"
+	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -151,6 +156,10 @@ func TestCRDReconcile_Drift_FailClosed_RevertsAndFails(t *testing.T) {
 	if got.Status.Phase != teraskyv1alpha1.PhaseFailed {
 		t.Fatalf("expected phase Failed under FailClosed drift, got %q (message: %s)", got.Status.Phase, got.Status.Message)
 	}
+	applied := meta.FindStatusCondition(got.Status.Conditions, teraskyv1alpha1.ConditionApplied)
+	if applied == nil || applied.Status != metav1.ConditionFalse || applied.Reason != "Reverted" {
+		t.Fatalf("expected ConditionApplied=False Reason=Reverted after successful FailClosed revert, got %+v", applied)
+	}
 
 	var patched extv1.CustomResourceDefinition
 	if err := r.Get(context.Background(), types.NamespacedName{Name: "foos.example.org"}, &patched); err != nil {
@@ -160,6 +169,82 @@ func TestCRDReconcile_Drift_FailClosed_RevertsAndFails(t *testing.T) {
 		t.Fatalf("expected the CRD to be reverted to strategy=None, got %+v", patched.Spec.Conversion)
 	}
 }
+
+func TestCRDReconcile_Drift_FailClosed_RevertFailure_HonestStatus(t *testing.T) {
+	crd := establishedCRD("foos.example.org")
+	crd.Spec.Conversion = &extv1.CustomResourceConversion{
+		Strategy: extv1.WebhookConverter,
+		Webhook: &extv1.WebhookConversion{
+			ClientConfig: &extv1.WebhookClientConfig{URL: strPtr("https://example.invalid/convert")},
+		},
+	}
+	cfg := renameRuleCRDConfig("cfg", "foos.example.org")
+	cfg.Spec.DriftPolicy = teraskyv1alpha1.DriftPolicyFailClosed
+	cfg.Status.Phase = teraskyv1alpha1.PhaseApplied
+	meta.SetStatusCondition(&cfg.Status.Conditions, metav1.Condition{
+		Type: teraskyv1alpha1.ConditionApplied, Status: metav1.ConditionTrue, Reason: "Applied", Message: "previously applied",
+	})
+	controllerutil.AddFinalizer(cfg, teraskyv1alpha1.CRDConversionConfigFinalizer)
+	server, secret := readyServer("srv")
+
+	c := newFakeClient(crd, cfg, server, secret).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Apply: func(ctx context.Context, c client.WithWatch, obj runtime.ApplyConfiguration, opts ...client.ApplyOption) error {
+				return fmt.Errorf("injected apply failure")
+			},
+		}).
+		Build()
+	r := &CRDConversionConfigReconciler{Client: c, DefaultServerNamespace: "operator-ns"}
+
+	live := getCRDConfig(t, r, "cfg")
+	live.Spec.Spokes[0].Rules[0].FieldRename.HubPath = "spec.doesNotExist"
+	if err := r.Update(context.Background(), live); err != nil {
+		t.Fatalf("updating config: %v", err)
+	}
+
+	_, err := reconcileCRD(t, r, "cfg")
+	if err == nil {
+		t.Fatalf("expected reconcile to return an error so the work is requeued with backoff")
+	}
+	if !strings.Contains(err.Error(), "injected apply failure") {
+		t.Fatalf("expected wrapped revert error, got: %v", err)
+	}
+
+	got := getCRDConfig(t, r, "cfg")
+	if got.Status.Phase != teraskyv1alpha1.PhaseFailed {
+		t.Fatalf("expected phase Failed after revert failure, got %q", got.Status.Phase)
+	}
+	if strings.Contains(got.Status.Message, "reverted to strategy=None") {
+		t.Fatalf("status must not claim a successful revert; message=%q", got.Status.Message)
+	}
+	if !strings.Contains(got.Status.Message, "failed to revert") {
+		t.Fatalf("expected honest failed-to-revert message, got %q", got.Status.Message)
+	}
+	applied := meta.FindStatusCondition(got.Status.Conditions, teraskyv1alpha1.ConditionApplied)
+	if applied == nil || applied.Status != metav1.ConditionFalse || applied.Reason != "RevertFailed" {
+		t.Fatalf("expected ConditionApplied=False Reason=RevertFailed, got %+v", applied)
+	}
+
+	var liveCRD extv1.CustomResourceDefinition
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "foos.example.org"}, &liveCRD); err != nil {
+		t.Fatalf("getting CRD: %v", err)
+	}
+	if liveCRD.Spec.Conversion == nil || liveCRD.Spec.Conversion.Strategy != extv1.WebhookConverter {
+		t.Fatalf("expected live CRD conversion to remain Webhook after failed revert, got %+v", liveCRD.Spec.Conversion)
+	}
+
+	_, err = reconcileCRD(t, r, "cfg")
+	if err == nil {
+		t.Fatalf("expected second reconcile to keep returning revert errors for backoff requeue")
+	}
+	got = getCRDConfig(t, r, "cfg")
+	applied = meta.FindStatusCondition(got.Status.Conditions, teraskyv1alpha1.ConditionApplied)
+	if applied == nil || applied.Reason != "RevertFailed" {
+		t.Fatalf("expected RevertFailed to remain so FailClosed keeps retrying, got %+v", applied)
+	}
+}
+
+func strPtr(s string) *string { return &s }
 
 func TestCRDReconcile_Drift_KeepServingStale(t *testing.T) {
 	crd := establishedCRD("foos.example.org")

--- a/internal/controller/crdconversionconfig_controller_test.go
+++ b/internal/controller/crdconversionconfig_controller_test.go
@@ -157,7 +157,7 @@ func TestCRDReconcile_Drift_FailClosed_RevertsAndFails(t *testing.T) {
 		t.Fatalf("expected phase Failed under FailClosed drift, got %q (message: %s)", got.Status.Phase, got.Status.Message)
 	}
 	applied := meta.FindStatusCondition(got.Status.Conditions, teraskyv1alpha1.ConditionApplied)
-	if applied == nil || applied.Status != metav1.ConditionFalse || applied.Reason != "Reverted" {
+	if applied == nil || applied.Status != metav1.ConditionFalse || applied.Reason != teraskyv1alpha1.ReasonReverted {
 		t.Fatalf("expected ConditionApplied=False Reason=Reverted after successful FailClosed revert, got %+v", applied)
 	}
 
@@ -221,7 +221,7 @@ func TestCRDReconcile_Drift_FailClosed_RevertFailure_HonestStatus(t *testing.T) 
 		t.Fatalf("expected honest failed-to-revert message, got %q", got.Status.Message)
 	}
 	applied := meta.FindStatusCondition(got.Status.Conditions, teraskyv1alpha1.ConditionApplied)
-	if applied == nil || applied.Status != metav1.ConditionFalse || applied.Reason != "RevertFailed" {
+	if applied == nil || applied.Status != metav1.ConditionFalse || applied.Reason != teraskyv1alpha1.ReasonRevertFailed {
 		t.Fatalf("expected ConditionApplied=False Reason=RevertFailed, got %+v", applied)
 	}
 
@@ -239,7 +239,7 @@ func TestCRDReconcile_Drift_FailClosed_RevertFailure_HonestStatus(t *testing.T) 
 	}
 	got = getCRDConfig(t, r, "cfg")
 	applied = meta.FindStatusCondition(got.Status.Conditions, teraskyv1alpha1.ConditionApplied)
-	if applied == nil || applied.Reason != "RevertFailed" {
+	if applied == nil || applied.Reason != teraskyv1alpha1.ReasonRevertFailed {
 		t.Fatalf("expected RevertFailed to remain so FailClosed keeps retrying, got %+v", applied)
 	}
 }

--- a/internal/controller/xrdconversionconfig_controller.go
+++ b/internal/controller/xrdconversionconfig_controller.go
@@ -147,14 +147,14 @@ func (r *XRDConversionConfigReconciler) reconcileNormal(ctx context.Context, cfg
 				meta.RemoveStatusCondition(&cfg.Status.Conditions, teraskyv1alpha1.ConditionStale)
 				msg = fmt.Sprintf("schema drift invalidated a previously-applied config; failed to revert to strategy=None per driftPolicy=FailClosed: %v", err)
 				meta.SetStatusCondition(&cfg.Status.Conditions, metav1.Condition{
-					Type: teraskyv1alpha1.ConditionApplied, Status: metav1.ConditionFalse, Reason: "RevertFailed", Message: msg,
+					Type: teraskyv1alpha1.ConditionApplied, Status: metav1.ConditionFalse, Reason: teraskyv1alpha1.ReasonRevertFailed, Message: msg,
 				})
 			} else {
 				cfg.Status.Phase = teraskyv1alpha1.PhaseFailed
 				meta.RemoveStatusCondition(&cfg.Status.Conditions, teraskyv1alpha1.ConditionStale)
 				msg = "schema drift invalidated a previously-applied config; reverted to strategy=None per driftPolicy=FailClosed"
 				meta.SetStatusCondition(&cfg.Status.Conditions, metav1.Condition{
-					Type: teraskyv1alpha1.ConditionApplied, Status: metav1.ConditionFalse, Reason: "Reverted", Message: msg,
+					Type: teraskyv1alpha1.ConditionApplied, Status: metav1.ConditionFalse, Reason: teraskyv1alpha1.ReasonReverted, Message: msg,
 				})
 			}
 		} else if wasApplied {
@@ -292,7 +292,7 @@ func failClosedShouldRevert(driftPolicy teraskyv1alpha1.DriftPolicy, phase strin
 	}
 	if phase == teraskyv1alpha1.PhaseFailed {
 		cond := meta.FindStatusCondition(conditions, teraskyv1alpha1.ConditionApplied)
-		return cond != nil && cond.Status == metav1.ConditionFalse && cond.Reason == "RevertFailed"
+		return cond != nil && cond.Status == metav1.ConditionFalse && cond.Reason == teraskyv1alpha1.ReasonRevertFailed
 	}
 	return false
 }

--- a/internal/controller/xrdconversionconfig_controller.go
+++ b/internal/controller/xrdconversionconfig_controller.go
@@ -133,14 +133,30 @@ func (r *XRDConversionConfigReconciler) reconcileNormal(ctx context.Context, cfg
 
 	if report.HasErrors() {
 		msg := "one or more spoke versions failed validation; see status.spokeStatuses for details"
-		if wasApplied && cfg.Spec.DriftPolicy == teraskyv1alpha1.DriftPolicyFailClosed {
+		var revertErr error
+		if failClosedShouldRevert(cfg.Spec.DriftPolicy, cfg.Status.Phase, cfg.Status.Conditions) {
 			if err := r.revertXRD(ctx, cfg.Spec.TargetXRD.Name); err != nil {
+				// Do not claim a successful revert: the XRD may still be
+				// serving webhook conversion. Keep Phase=Failed with an
+				// honest message, surface RevertFailed on ConditionApplied,
+				// and return the error so reconcile requeues with backoff.
+				revertErr = err
 				logger := log.FromContext(ctx)
 				logger.Error(err, "failed to revert XRD after drift under FailClosed policy")
+				cfg.Status.Phase = teraskyv1alpha1.PhaseFailed
+				meta.RemoveStatusCondition(&cfg.Status.Conditions, teraskyv1alpha1.ConditionStale)
+				msg = fmt.Sprintf("schema drift invalidated a previously-applied config; failed to revert to strategy=None per driftPolicy=FailClosed: %v", err)
+				meta.SetStatusCondition(&cfg.Status.Conditions, metav1.Condition{
+					Type: teraskyv1alpha1.ConditionApplied, Status: metav1.ConditionFalse, Reason: "RevertFailed", Message: msg,
+				})
+			} else {
+				cfg.Status.Phase = teraskyv1alpha1.PhaseFailed
+				meta.RemoveStatusCondition(&cfg.Status.Conditions, teraskyv1alpha1.ConditionStale)
+				msg = "schema drift invalidated a previously-applied config; reverted to strategy=None per driftPolicy=FailClosed"
+				meta.SetStatusCondition(&cfg.Status.Conditions, metav1.Condition{
+					Type: teraskyv1alpha1.ConditionApplied, Status: metav1.ConditionFalse, Reason: "Reverted", Message: msg,
+				})
 			}
-			cfg.Status.Phase = teraskyv1alpha1.PhaseFailed
-			meta.RemoveStatusCondition(&cfg.Status.Conditions, teraskyv1alpha1.ConditionStale)
-			msg = "schema drift invalidated a previously-applied config; reverted to strategy=None per driftPolicy=FailClosed"
 		} else if wasApplied {
 			// Conservative default: keep serving the last known-good
 			// compiled plan (unchanged on the XRD) and mark Stale rather
@@ -155,7 +171,13 @@ func (r *XRDConversionConfigReconciler) reconcileNormal(ctx context.Context, cfg
 			Type: teraskyv1alpha1.ConditionValidated, Status: metav1.ConditionFalse, Reason: "ValidationFailed", Message: msg,
 		})
 		cfg.Status.Message = msg
-		return ctrl.Result{}, r.patchStatus(ctx, orig, cfg)
+		if err := r.patchStatus(ctx, orig, cfg); err != nil {
+			return ctrl.Result{}, err
+		}
+		if revertErr != nil {
+			return ctrl.Result{}, fmt.Errorf("reverting XRD after FailClosed drift: %w", revertErr)
+		}
+		return ctrl.Result{}, nil
 	}
 
 	meta.SetStatusCondition(&cfg.Status.Conditions, metav1.Condition{
@@ -254,6 +276,25 @@ func phasePending(wasApplied bool) string {
 		return teraskyv1alpha1.PhaseStale
 	}
 	return teraskyv1alpha1.PhasePending
+}
+
+// failClosedShouldRevert reports whether FailClosed drift handling must
+// (re)attempt tearing down the live webhook conversion config. True while
+// Phase is still Applied, and also while a previous FailClosed revert failed
+// (Phase=Failed with ConditionApplied Reason=RevertFailed) so we keep
+// retrying instead of treating status as a successful tear-down.
+func failClosedShouldRevert(driftPolicy teraskyv1alpha1.DriftPolicy, phase string, conditions []metav1.Condition) bool {
+	if driftPolicy != teraskyv1alpha1.DriftPolicyFailClosed {
+		return false
+	}
+	if phase == teraskyv1alpha1.PhaseApplied {
+		return true
+	}
+	if phase == teraskyv1alpha1.PhaseFailed {
+		cond := meta.FindStatusCondition(conditions, teraskyv1alpha1.ConditionApplied)
+		return cond != nil && cond.Status == metav1.ConditionFalse && cond.Reason == "RevertFailed"
+	}
+	return false
 }
 
 // setPhaseStale sets Phase=Stale and ConditionStale=True so monitors that

--- a/internal/controller/xrdconversionconfig_controller_reconcile_test.go
+++ b/internal/controller/xrdconversionconfig_controller_reconcile_test.go
@@ -18,12 +18,17 @@ package controller
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -235,6 +240,10 @@ func TestXRDReconcile_Drift_FailClosed_RevertsAndFails(t *testing.T) {
 	if got.Status.Phase != teraskyv1alpha1.PhaseFailed {
 		t.Fatalf("expected phase Failed under FailClosed drift, got %q (message: %s)", got.Status.Phase, got.Status.Message)
 	}
+	applied := meta.FindStatusCondition(got.Status.Conditions, teraskyv1alpha1.ConditionApplied)
+	if applied == nil || applied.Status != metav1.ConditionFalse || applied.Reason != "Reverted" {
+		t.Fatalf("expected ConditionApplied=False Reason=Reverted after successful FailClosed revert, got %+v", applied)
+	}
 
 	patchedXRD := &unstructured.Unstructured{}
 	patchedXRD.SetGroupVersionKind(xrdadapter.GroupVersionKind)
@@ -244,6 +253,86 @@ func TestXRDReconcile_Drift_FailClosed_RevertsAndFails(t *testing.T) {
 	strategy, found := stringField(patchedXRD.Object, "spec", "conversion", "strategy")
 	if !found || strategy != "None" {
 		t.Fatalf("expected the XRD to be reverted to strategy=None, found=%v strategy=%q", found, strategy)
+	}
+}
+
+func TestXRDReconcile_Drift_FailClosed_RevertFailure_HonestStatus(t *testing.T) {
+	xrd := establishedXRD("xfoos.example.org")
+	// Pretend the live XRD still has webhook conversion wired.
+	_ = unstructured.SetNestedMap(xrd.Object, map[string]any{
+		"strategy": "Webhook",
+		"webhook":  map[string]any{"clientConfig": map[string]any{"url": "https://example.invalid/convert"}},
+	}, "spec", "conversion")
+	cfg := renameRuleXRDConfig("cfg", "xfoos.example.org")
+	cfg.Spec.DriftPolicy = teraskyv1alpha1.DriftPolicyFailClosed
+	cfg.Status.Phase = teraskyv1alpha1.PhaseApplied
+	meta.SetStatusCondition(&cfg.Status.Conditions, metav1.Condition{
+		Type: teraskyv1alpha1.ConditionApplied, Status: metav1.ConditionTrue, Reason: "Applied", Message: "previously applied",
+	})
+	controllerutil.AddFinalizer(cfg, teraskyv1alpha1.XRDConversionConfigFinalizer)
+	server, secret := readyServer("srv")
+
+	c := newFakeClient(cfg, server, secret).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Apply: func(ctx context.Context, c client.WithWatch, obj runtime.ApplyConfiguration, opts ...client.ApplyOption) error {
+				return fmt.Errorf("injected apply failure")
+			},
+		}).
+		Build()
+	if err := c.Create(context.Background(), xrd); err != nil {
+		t.Fatalf("creating XRD fixture: %v", err)
+	}
+	r := &XRDConversionConfigReconciler{Client: c, DefaultServerNamespace: "operator-ns"}
+
+	live := getXRDConfig(t, r, "cfg")
+	live.Spec.Spokes[0].Rules[0].FieldRename.HubPath = "spec.doesNotExist"
+	if err := r.Update(context.Background(), live); err != nil {
+		t.Fatalf("updating config: %v", err)
+	}
+
+	_, err := reconcileXRD(t, r, "cfg")
+	if err == nil {
+		t.Fatalf("expected reconcile to return an error so the work is requeued with backoff")
+	}
+	if !strings.Contains(err.Error(), "injected apply failure") {
+		t.Fatalf("expected wrapped revert error, got: %v", err)
+	}
+
+	got := getXRDConfig(t, r, "cfg")
+	if got.Status.Phase != teraskyv1alpha1.PhaseFailed {
+		t.Fatalf("expected phase Failed after revert failure, got %q", got.Status.Phase)
+	}
+	if strings.Contains(got.Status.Message, "reverted to strategy=None") {
+		t.Fatalf("status must not claim a successful revert; message=%q", got.Status.Message)
+	}
+	if !strings.Contains(got.Status.Message, "failed to revert") {
+		t.Fatalf("expected honest failed-to-revert message, got %q", got.Status.Message)
+	}
+	applied := meta.FindStatusCondition(got.Status.Conditions, teraskyv1alpha1.ConditionApplied)
+	if applied == nil || applied.Status != metav1.ConditionFalse || applied.Reason != "RevertFailed" {
+		t.Fatalf("expected ConditionApplied=False Reason=RevertFailed, got %+v", applied)
+	}
+
+	liveXRD := &unstructured.Unstructured{}
+	liveXRD.SetGroupVersionKind(xrdadapter.GroupVersionKind)
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "xfoos.example.org"}, liveXRD); err != nil {
+		t.Fatalf("getting XRD: %v", err)
+	}
+	strategy, found := stringField(liveXRD.Object, "spec", "conversion", "strategy")
+	if !found || strategy != "Webhook" {
+		t.Fatalf("expected live XRD conversion to remain Webhook after failed revert, found=%v strategy=%q", found, strategy)
+	}
+
+	// A subsequent reconcile with the same injected failure must keep
+	// retrying FailClosed revert (not treat Phase=Failed as terminal success).
+	_, err = reconcileXRD(t, r, "cfg")
+	if err == nil {
+		t.Fatalf("expected second reconcile to keep returning revert errors for backoff requeue")
+	}
+	got = getXRDConfig(t, r, "cfg")
+	applied = meta.FindStatusCondition(got.Status.Conditions, teraskyv1alpha1.ConditionApplied)
+	if applied == nil || applied.Reason != "RevertFailed" {
+		t.Fatalf("expected RevertFailed to remain so FailClosed keeps retrying, got %+v", applied)
 	}
 }
 

--- a/internal/controller/xrdconversionconfig_controller_reconcile_test.go
+++ b/internal/controller/xrdconversionconfig_controller_reconcile_test.go
@@ -241,7 +241,7 @@ func TestXRDReconcile_Drift_FailClosed_RevertsAndFails(t *testing.T) {
 		t.Fatalf("expected phase Failed under FailClosed drift, got %q (message: %s)", got.Status.Phase, got.Status.Message)
 	}
 	applied := meta.FindStatusCondition(got.Status.Conditions, teraskyv1alpha1.ConditionApplied)
-	if applied == nil || applied.Status != metav1.ConditionFalse || applied.Reason != "Reverted" {
+	if applied == nil || applied.Status != metav1.ConditionFalse || applied.Reason != teraskyv1alpha1.ReasonReverted {
 		t.Fatalf("expected ConditionApplied=False Reason=Reverted after successful FailClosed revert, got %+v", applied)
 	}
 
@@ -259,10 +259,12 @@ func TestXRDReconcile_Drift_FailClosed_RevertsAndFails(t *testing.T) {
 func TestXRDReconcile_Drift_FailClosed_RevertFailure_HonestStatus(t *testing.T) {
 	xrd := establishedXRD("xfoos.example.org")
 	// Pretend the live XRD still has webhook conversion wired.
-	_ = unstructured.SetNestedMap(xrd.Object, map[string]any{
+	if err := unstructured.SetNestedMap(xrd.Object, map[string]any{
 		"strategy": "Webhook",
 		"webhook":  map[string]any{"clientConfig": map[string]any{"url": "https://example.invalid/convert"}},
-	}, "spec", "conversion")
+	}, "spec", "conversion"); err != nil {
+		t.Fatalf("seeding webhook conversion on the XRD fixture: %v", err)
+	}
 	cfg := renameRuleXRDConfig("cfg", "xfoos.example.org")
 	cfg.Spec.DriftPolicy = teraskyv1alpha1.DriftPolicyFailClosed
 	cfg.Status.Phase = teraskyv1alpha1.PhaseApplied
@@ -309,7 +311,7 @@ func TestXRDReconcile_Drift_FailClosed_RevertFailure_HonestStatus(t *testing.T) 
 		t.Fatalf("expected honest failed-to-revert message, got %q", got.Status.Message)
 	}
 	applied := meta.FindStatusCondition(got.Status.Conditions, teraskyv1alpha1.ConditionApplied)
-	if applied == nil || applied.Status != metav1.ConditionFalse || applied.Reason != "RevertFailed" {
+	if applied == nil || applied.Status != metav1.ConditionFalse || applied.Reason != teraskyv1alpha1.ReasonRevertFailed {
 		t.Fatalf("expected ConditionApplied=False Reason=RevertFailed, got %+v", applied)
 	}
 
@@ -331,7 +333,7 @@ func TestXRDReconcile_Drift_FailClosed_RevertFailure_HonestStatus(t *testing.T) 
 	}
 	got = getXRDConfig(t, r, "cfg")
 	applied = meta.FindStatusCondition(got.Status.Conditions, teraskyv1alpha1.ConditionApplied)
-	if applied == nil || applied.Reason != "RevertFailed" {
+	if applied == nil || applied.Reason != teraskyv1alpha1.ReasonRevertFailed {
 		t.Fatalf("expected RevertFailed to remain so FailClosed keeps retrying, got %+v", applied)
 	}
 }


### PR DESCRIPTION
## Summary
- When FailClosed drift revert (`revertXRD`/`revertCRD`) fails, status no longer claims `reverted to strategy=None`; Phase stays `Failed` with an accurate message and `ConditionApplied=False` Reason=`RevertFailed`.
- Reconcile returns the revert error so controller-runtime requeues with backoff, and `failClosedShouldRevert` keeps retrying until the tear-down succeeds (then Reason=`Reverted`).
- Mirrored in XRD and CRD controllers; unit tests inject Apply failures and assert no false "reverted" claim.

Closes #10

## Test plan
- [x] `go test ./internal/controller/ -run FailClosed`
- [x] `make test`
- [x] `make test-e2e`
- [ ] Confirm happy-path FailClosed still sets Phase=Failed, strategy=None, Reason=Reverted
- [ ] Confirm injected Apply failure path: message contains `failed to revert`, Reason=RevertFailed, live strategy remains Webhook, reconcile error returned

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of schema drift in fail-closed conversion configurations.
  - Rollback failures now report an accurate failed status and preserve the active webhook configuration.
  - Successful rollbacks clearly indicate that the configuration was reverted.
  - Failed rollbacks now trigger reconciliation retries, improving recovery from temporary errors.
  - Status updates are saved before errors are returned, providing more reliable visibility into conversion state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->