### PR TITLE
0.7: wire ConversionWebhookServer.spec.extraArgs

### DIFF
--- a/api/v1alpha1/conversionwebhookserver_types.go
+++ b/api/v1alpha1/conversionwebhookserver_types.go
@@ -124,6 +124,16 @@ type ConversionWebhookServerSpec struct {
 	// +optional
 	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 
+	// ExtraArgs are additional container arguments appended after the
+	// operator-managed flags (--webhook-server-name, --tls-cert-dir,
+	// bind addresses, and feature toggles). Use for optional webhook-server
+	// flags such as --cert-reload-interval or zap logging options. Do not
+	// override operator-managed flags; doing so can break identity, TLS, or
+	// feature wiring for this instance. Webhook-server pods are configured
+	// via this CR (not Helm conversionWebhookServer.* Deployment keys).
+	// +optional
+	ExtraArgs []string `json:"extraArgs,omitempty"`
+
 	Certificate CertificateSpec `json:"certificate"`
 	// +optional
 	Service ServiceSpec `json:"service,omitempty"`

--- a/api/v1alpha1/conversionwebhookserver_types.go
+++ b/api/v1alpha1/conversionwebhookserver_types.go
@@ -127,9 +127,10 @@ type ConversionWebhookServerSpec struct {
 	// ExtraArgs are additional container arguments appended after the
 	// operator-managed flags (--webhook-server-name, --tls-cert-dir,
 	// bind addresses, and feature toggles). Use for optional webhook-server
-	// flags such as --cert-reload-interval or zap logging options. Do not
-	// override operator-managed flags; doing so can break identity, TLS, or
-	// feature wiring for this instance. Webhook-server pods are configured
+	// flags such as --cert-reload-interval or zap logging options.
+	// Admission and reconcile reject ExtraArgs that name those managed
+	// flags (--flag=value or --flag value); overriding them would break
+	// identity, TLS, or feature wiring. Webhook-server pods are configured
 	// via this CR (not Helm conversionWebhookServer.* Deployment keys).
 	// +optional
 	ExtraArgs []string `json:"extraArgs,omitempty"`

--- a/api/v1alpha1/extra_args.go
+++ b/api/v1alpha1/extra_args.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2026 The declarative-conversion-operator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"fmt"
+	"strings"
+)
+
+// operatorManagedWebhookServerFlagNames are flags the ConversionWebhookServer
+// controller always injects. ExtraArgs must not override them — Go's flag
+// package keeps the last value, so a later duplicate would silently break
+// identity, TLS, bind addresses, or feature wiring.
+var operatorManagedWebhookServerFlagNames = map[string]struct{}{
+	"webhook-server-name":     {},
+	"tls-cert-dir":            {},
+	"conversion-bind-address": {},
+	"metrics-bind-address":    {},
+	"enable-xrd-support":      {},
+	"enable-crd-support":      {},
+}
+
+// ValidateWebhookServerExtraArgs rejects ExtraArgs entries that name an
+// operator-managed webhook-server flag. Both `--flag=value` and `--flag value`
+// forms are detected; other optional flags pass through unchanged.
+func ValidateWebhookServerExtraArgs(args []string) error {
+	for i := 0; i < len(args); i++ {
+		name, ok := longFlagName(args[i])
+		if !ok {
+			continue
+		}
+		if _, managed := operatorManagedWebhookServerFlagNames[name]; managed {
+			return fmt.Errorf("extraArgs must not override operator-managed flag %q", name)
+		}
+		// `--flag value` (no '='): skip the following value token so it is
+		// not misread as another flag name.
+		if !strings.Contains(args[i], "=") && i+1 < len(args) && !strings.HasPrefix(args[i+1], "-") {
+			i++
+		}
+	}
+	return nil
+}
+
+func longFlagName(arg string) (string, bool) {
+	if !strings.HasPrefix(arg, "--") {
+		return "", false
+	}
+	name := strings.TrimPrefix(arg, "--")
+	if name == "" {
+		return "", false
+	}
+	if eq := strings.IndexByte(name, '='); eq >= 0 {
+		name = name[:eq]
+	}
+	return name, name != ""
+}

--- a/api/v1alpha1/extra_args_test.go
+++ b/api/v1alpha1/extra_args_test.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2026 The declarative-conversion-operator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import "testing"
+
+func TestValidateWebhookServerExtraArgs(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		args    []string
+		wantErr bool
+	}{
+		{name: "nil", args: nil},
+		{name: "optional only", args: []string{"--cert-reload-interval=1m", "--zap-devel=true"}},
+		{name: "equals form managed", args: []string{"--webhook-server-name=evil"}, wantErr: true},
+		{name: "two-token managed", args: []string{"--tls-cert-dir", "/evil"}, wantErr: true},
+		{name: "bool managed bare", args: []string{"--enable-xrd-support=false"}, wantErr: true},
+		{name: "bind address managed", args: []string{"--metrics-bind-address=:9999"}, wantErr: true},
+		{name: "value looks like flag name", args: []string{"--cert-reload-interval", "webhook-server-name"}},
+		{name: "mixed optional then managed", args: []string{"--zap-devel=true", "--conversion-bind-address=:1"}, wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateWebhookServerExtraArgs(tc.args)
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error for %v", tc.args)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error for %v: %v", tc.args, err)
+			}
+		})
+	}
+}

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -483,6 +483,11 @@ func (in *ConversionWebhookServerSpec) DeepCopyInto(out *ConversionWebhookServer
 		*out = new(corev1.Affinity)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.ExtraArgs != nil {
+		in, out := &in.ExtraArgs, &out.ExtraArgs
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	in.Certificate.DeepCopyInto(&out.Certificate)
 	in.Service.DeepCopyInto(&out.Service)
 	if in.PodDisruptionBudget != nil {

--- a/charts/declarative-conversion-operator/README.md
+++ b/charts/declarative-conversion-operator/README.md
@@ -54,7 +54,7 @@ See `values.yaml` for the full set.
 
 ## Multiple ConversionWebhookServer instances
 
-Create additional instances directly as `ConversionWebhookServer` custom resources (not via this chart) for scale-out or tenancy — each gets its own Deployment/Service/Certificate/HPA/PDB, reconciled by the operator:
+Create additional instances directly as `ConversionWebhookServer` custom resources (not via this chart) for scale-out or tenancy — each gets its own Deployment/Service/Certificate/HPA/PDB, reconciled by the operator. Pod-level settings such as `spec.extraArgs` are configured on the CR (the chart does not template a Deployment for webhook-server pods):
 
 ```yaml
 apiVersion: terasky.com/v1alpha1
@@ -64,6 +64,8 @@ metadata:
 spec:
   certificate:
     issuerRef: {name: my-ca-issuer, kind: ClusterIssuer}
+  extraArgs:
+    - --cert-reload-interval=1m
 ```
 
 Then reference it from an `XRDConversionConfig` via `spec.webhookServerRef.name: tenant-a`.

--- a/charts/declarative-conversion-operator/crds/terasky.com_conversionwebhookservers.yaml
+++ b/charts/declarative-conversion-operator/crds/terasky.com_conversionwebhookservers.yaml
@@ -1028,6 +1028,18 @@ spec:
                   one instance may be default at a time; the admission webhook
                   rejects setting a second one.
                 type: boolean
+              extraArgs:
+                description: |-
+                  ExtraArgs are additional container arguments appended after the
+                  operator-managed flags (--webhook-server-name, --tls-cert-dir,
+                  bind addresses, and feature toggles). Use for optional webhook-server
+                  flags such as --cert-reload-interval or zap logging options. Do not
+                  override operator-managed flags; doing so can break identity, TLS, or
+                  feature wiring for this instance. Webhook-server pods are configured
+                  via this CR (not Helm conversionWebhookServer.* Deployment keys).
+                items:
+                  type: string
+                type: array
               image:
                 description: |-
                   ImageSpec overrides the container image used for a ConversionWebhookServer

--- a/charts/declarative-conversion-operator/crds/terasky.com_conversionwebhookservers.yaml
+++ b/charts/declarative-conversion-operator/crds/terasky.com_conversionwebhookservers.yaml
@@ -1033,9 +1033,10 @@ spec:
                   ExtraArgs are additional container arguments appended after the
                   operator-managed flags (--webhook-server-name, --tls-cert-dir,
                   bind addresses, and feature toggles). Use for optional webhook-server
-                  flags such as --cert-reload-interval or zap logging options. Do not
-                  override operator-managed flags; doing so can break identity, TLS, or
-                  feature wiring for this instance. Webhook-server pods are configured
+                  flags such as --cert-reload-interval or zap logging options.
+                  Admission and reconcile reject ExtraArgs that name those managed
+                  flags (--flag=value or --flag value); overriding them would break
+                  identity, TLS, or feature wiring. Webhook-server pods are configured
                   via this CR (not Helm conversionWebhookServer.* Deployment keys).
                 items:
                   type: string

--- a/charts/declarative-conversion-operator/values.yaml
+++ b/charts/declarative-conversion-operator/values.yaml
@@ -98,6 +98,8 @@ certManager:
 # reconciles that CR into the real child resources, so templating them here
 # too would fight the controller's reconciliation loop. Create additional
 # instances directly as ConversionWebhookServer CRs for scale-out/tenancy.
+# Pod-level knobs that aren't listed below (notably spec.extraArgs) are set
+# on the ConversionWebhookServer CR itself — see docs/configuration/conversionwebhookserver.md.
 conversionWebhookServer:
   create: true
   name: default
@@ -126,7 +128,6 @@ conversionWebhookServer:
     type: ClusterIP
     port: 443
     annotations: {}
-  extraArgs: []
   nodeSelector: {}
   tolerations: []
   affinity: {}

--- a/config/crd/bases/terasky.com_conversionwebhookservers.yaml
+++ b/config/crd/bases/terasky.com_conversionwebhookservers.yaml
@@ -1028,6 +1028,18 @@ spec:
                   one instance may be default at a time; the admission webhook
                   rejects setting a second one.
                 type: boolean
+              extraArgs:
+                description: |-
+                  ExtraArgs are additional container arguments appended after the
+                  operator-managed flags (--webhook-server-name, --tls-cert-dir,
+                  bind addresses, and feature toggles). Use for optional webhook-server
+                  flags such as --cert-reload-interval or zap logging options. Do not
+                  override operator-managed flags; doing so can break identity, TLS, or
+                  feature wiring for this instance. Webhook-server pods are configured
+                  via this CR (not Helm conversionWebhookServer.* Deployment keys).
+                items:
+                  type: string
+                type: array
               image:
                 description: |-
                   ImageSpec overrides the container image used for a ConversionWebhookServer

--- a/config/crd/bases/terasky.com_conversionwebhookservers.yaml
+++ b/config/crd/bases/terasky.com_conversionwebhookservers.yaml
@@ -1033,9 +1033,10 @@ spec:
                   ExtraArgs are additional container arguments appended after the
                   operator-managed flags (--webhook-server-name, --tls-cert-dir,
                   bind addresses, and feature toggles). Use for optional webhook-server
-                  flags such as --cert-reload-interval or zap logging options. Do not
-                  override operator-managed flags; doing so can break identity, TLS, or
-                  feature wiring for this instance. Webhook-server pods are configured
+                  flags such as --cert-reload-interval or zap logging options.
+                  Admission and reconcile reject ExtraArgs that name those managed
+                  flags (--flag=value or --flag value); overriding them would break
+                  identity, TLS, or feature wiring. Webhook-server pods are configured
                   via this CR (not Helm conversionWebhookServer.* Deployment keys).
                 items:
                   type: string

--- a/docs/configuration/conversionwebhookserver.md
+++ b/docs/configuration/conversionwebhookserver.md
@@ -32,7 +32,7 @@ spec:
 | `autoscaling.{minReplicas,maxReplicas,targetCPUUtilizationPercentage}` | Creates a `HorizontalPodAutoscaler` for this instance instead of a fixed count. |
 | `image.{repository,tag,pullPolicy}` | Overrides the webhook-server image for this instance. Omit to use the operator's own default (set via Helm `image.webhookServer.*` / a manager flag). |
 | `resources`, `nodeSelector`, `tolerations`, `affinity`, `priorityClassName`, `serviceAccountName` | Standard Kubernetes pod-scheduling knobs, applied to this instance's Deployment. |
-| `extraArgs` | Additional container arguments appended after operator-managed flags (`--webhook-server-name`, `--tls-cert-dir`, bind addresses, feature toggles). For optional webhook-server flags (e.g. `--cert-reload-interval`, zap options). Do not override the operator-managed flags. |
+| `extraArgs` | Additional container arguments appended after operator-managed flags (`--webhook-server-name`, `--tls-cert-dir`, bind addresses, feature toggles). For optional webhook-server flags (e.g. `--cert-reload-interval`, zap options). Admission and reconcile reject ExtraArgs that name those managed flags. |
 | `certificate.issuerRef` | The cert-manager `Issuer`/`ClusterIssuer` for this instance's webhook TLS certificate. `certificate.dnsNames`, `.duration`, `.renewBefore` are also available. |
 | `service.{type,port,annotations}` | The `Service` fronting this instance's pods. |
 | `podDisruptionBudget.{minAvailable,maxUnavailable}` | Creates a `PodDisruptionBudget` for this instance. |

--- a/docs/configuration/conversionwebhookserver.md
+++ b/docs/configuration/conversionwebhookserver.md
@@ -2,7 +2,7 @@
 
 A `ConversionWebhookServer` is a deployable, independently scalable instance of the shared conversion webhook runtime — the thing that actually receives `ConversionReview` requests from the apiserver and converts objects. The Helm chart creates exactly one, named `default` and marked `spec.default: true`; create more directly as CRs for scale-out or tenant isolation.
 
-It's cluster-scoped, but its owned resources (Deployment, Service, Certificate, HPA, PDB) live in a real namespace given by `spec.namespace` (defaulting to the operator's own install namespace).
+It's cluster-scoped, but its owned resources (Deployment, Service, Certificate, HPA, PDB) live in a real namespace given by `spec.namespace` (defaulting to the operator's own install namespace). The Deployment itself is built by the operator from this CR — not from Helm templates — so pod args and similar knobs live here (for example `spec.extraArgs`), not under Helm `conversionWebhookServer.*`.
 
 ## Spec
 
@@ -14,6 +14,8 @@ metadata:
 spec:
   default: true
   replicas: 2
+  extraArgs:
+    - --cert-reload-interval=1m
   certificate:
     issuerRef:
       name: declarative-conversion-operator-selfsigned-issuer
@@ -30,6 +32,7 @@ spec:
 | `autoscaling.{minReplicas,maxReplicas,targetCPUUtilizationPercentage}` | Creates a `HorizontalPodAutoscaler` for this instance instead of a fixed count. |
 | `image.{repository,tag,pullPolicy}` | Overrides the webhook-server image for this instance. Omit to use the operator's own default (set via Helm `image.webhookServer.*` / a manager flag). |
 | `resources`, `nodeSelector`, `tolerations`, `affinity`, `priorityClassName`, `serviceAccountName` | Standard Kubernetes pod-scheduling knobs, applied to this instance's Deployment. |
+| `extraArgs` | Additional container arguments appended after operator-managed flags (`--webhook-server-name`, `--tls-cert-dir`, bind addresses, feature toggles). For optional webhook-server flags (e.g. `--cert-reload-interval`, zap options). Do not override the operator-managed flags. |
 | `certificate.issuerRef` | The cert-manager `Issuer`/`ClusterIssuer` for this instance's webhook TLS certificate. `certificate.dnsNames`, `.duration`, `.renewBefore` are also available. |
 | `service.{type,port,annotations}` | The `Service` fronting this instance's pods. |
 | `podDisruptionBudget.{minAvailable,maxUnavailable}` | Creates a `PodDisruptionBudget` for this instance. |

--- a/internal/controller/conversionwebhookserver_controller.go
+++ b/internal/controller/conversionwebhookserver_controller.go
@@ -329,6 +329,11 @@ func (r *ConversionWebhookServerReconciler) reconcileDeployment(ctx context.Cont
 
 	// Operator-managed flags first so identity/TLS/bind/feature wiring is
 	// always present; ExtraArgs are appended for optional flags only.
+	// Reject managed-flag overrides here too so a bypassed admission webhook
+	// cannot still rewrite identity/TLS/bind/feature args on the Deployment.
+	if err := teraskyv1alpha1.ValidateWebhookServerExtraArgs(server.Spec.ExtraArgs); err != nil {
+		return err
+	}
 	args := []string{
 		fmt.Sprintf("--webhook-server-name=%s", server.Name),
 		"--tls-cert-dir=/tls",

--- a/internal/controller/conversionwebhookserver_controller.go
+++ b/internal/controller/conversionwebhookserver_controller.go
@@ -327,17 +327,22 @@ func (r *ConversionWebhookServerReconciler) reconcileDeployment(ctx context.Cont
 	// When Autoscaling is set, replicas is left nil so the HPA owns it and
 	// this controller never fights it on every reconcile.
 
+	// Operator-managed flags first so identity/TLS/bind/feature wiring is
+	// always present; ExtraArgs are appended for optional flags only.
+	args := []string{
+		fmt.Sprintf("--webhook-server-name=%s", server.Name),
+		"--tls-cert-dir=/tls",
+		fmt.Sprintf("--conversion-bind-address=:%d", webhookServerConversionPort),
+		fmt.Sprintf("--metrics-bind-address=:%d", webhookServerMetricsPort),
+		fmt.Sprintf("--enable-xrd-support=%t", r.EnableXRDSupport),
+		fmt.Sprintf("--enable-crd-support=%t", r.EnableCRDSupport),
+	}
+	args = append(args, server.Spec.ExtraArgs...)
+
 	container := applycorev1.Container().
 		WithName("webhook-server").
 		WithImage(image).
-		WithArgs(
-			fmt.Sprintf("--webhook-server-name=%s", server.Name),
-			"--tls-cert-dir=/tls",
-			fmt.Sprintf("--conversion-bind-address=:%d", webhookServerConversionPort),
-			fmt.Sprintf("--metrics-bind-address=:%d", webhookServerMetricsPort),
-			fmt.Sprintf("--enable-xrd-support=%t", r.EnableXRDSupport),
-			fmt.Sprintf("--enable-crd-support=%t", r.EnableCRDSupport),
-		).
+		WithArgs(args...).
 		WithPorts(
 			applycorev1.ContainerPort().WithName("conversion").WithContainerPort(webhookServerConversionPort),
 			applycorev1.ContainerPort().WithName("metrics").WithContainerPort(webhookServerMetricsPort),

--- a/internal/controller/conversionwebhookserver_controller_test.go
+++ b/internal/controller/conversionwebhookserver_controller_test.go
@@ -51,6 +51,58 @@ func getCWS(t *testing.T, r *ConversionWebhookServerReconciler, name string) *te
 	return &s
 }
 
+func TestCWSReconcile_ExtraArgs_AppendedToDeployment(t *testing.T) {
+	server := &teraskyv1alpha1.ConversionWebhookServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "srv"},
+		Spec: teraskyv1alpha1.ConversionWebhookServerSpec{
+			Namespace: "operator-ns",
+			Certificate: teraskyv1alpha1.CertificateSpec{
+				IssuerRef: teraskyv1alpha1.CertificateIssuerRef{Name: "ca-issuer"},
+			},
+			ExtraArgs: []string{"--cert-reload-interval=1m", "--zap-devel=true"},
+		},
+	}
+	c := newFakeClient(server).Build()
+	r := &ConversionWebhookServerReconciler{
+		Client:           c,
+		Scheme:           newScheme(),
+		DefaultNamespace: "operator-ns",
+		DefaultImage:     "test/image:v1",
+		EnableXRDSupport: true,
+		EnableCRDSupport: false,
+	}
+
+	if _, err := reconcileCWS(t, r, "srv"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var dep appsv1.Deployment
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "srv-webhook-server", Namespace: "operator-ns"}, &dep); err != nil {
+		t.Fatalf("expected a Deployment to be created: %v", err)
+	}
+	if len(dep.Spec.Template.Spec.Containers) != 1 {
+		t.Fatalf("expected 1 container, got %d", len(dep.Spec.Template.Spec.Containers))
+	}
+	got := dep.Spec.Template.Spec.Containers[0].Args
+	wantPrefix := []string{
+		"--webhook-server-name=srv",
+		"--tls-cert-dir=/tls",
+		"--conversion-bind-address=:9443",
+		"--metrics-bind-address=:8443",
+		"--enable-xrd-support=true",
+		"--enable-crd-support=false",
+	}
+	want := append(append([]string{}, wantPrefix...), "--cert-reload-interval=1m", "--zap-devel=true")
+	if len(got) != len(want) {
+		t.Fatalf("args length: got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("args[%d]=%q, want %q (full got=%v)", i, got[i], want[i], got)
+		}
+	}
+}
+
 func TestCWSReconcile_HappyPath_CreatesChildResources(t *testing.T) {
 	server := &teraskyv1alpha1.ConversionWebhookServer{
 		ObjectMeta: metav1.ObjectMeta{Name: "srv"},

--- a/internal/controller/conversionwebhookserver_controller_test.go
+++ b/internal/controller/conversionwebhookserver_controller_test.go
@@ -103,6 +103,30 @@ func TestCWSReconcile_ExtraArgs_AppendedToDeployment(t *testing.T) {
 	}
 }
 
+func TestCWSReconcile_ExtraArgs_RejectsManagedFlag(t *testing.T) {
+	server := &teraskyv1alpha1.ConversionWebhookServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "srv"},
+		Spec: teraskyv1alpha1.ConversionWebhookServerSpec{
+			Namespace: "operator-ns",
+			Certificate: teraskyv1alpha1.CertificateSpec{
+				IssuerRef: teraskyv1alpha1.CertificateIssuerRef{Name: "ca-issuer"},
+			},
+			ExtraArgs: []string{"--tls-cert-dir", "/evil"},
+		},
+	}
+	c := newFakeClient(server).Build()
+	r := &ConversionWebhookServerReconciler{
+		Client:           c,
+		Scheme:           newScheme(),
+		DefaultNamespace: "operator-ns",
+		DefaultImage:     "test/image:v1",
+	}
+
+	if _, err := reconcileCWS(t, r, "srv"); err == nil {
+		t.Fatal("expected reconcile to fail when ExtraArgs override a managed flag")
+	}
+}
+
 func TestCWSReconcile_HappyPath_CreatesChildResources(t *testing.T) {
 	server := &teraskyv1alpha1.ConversionWebhookServer{
 		ObjectMeta: metav1.ObjectMeta{Name: "srv"},

--- a/internal/webhook/conversionwebhookserver_webhook.go
+++ b/internal/webhook/conversionwebhookserver_webhook.go
@@ -43,10 +43,16 @@ type ConversionWebhookServerValidator struct {
 var _ admission.Validator[*teraskyv1alpha1.ConversionWebhookServer] = &ConversionWebhookServerValidator{}
 
 func (v *ConversionWebhookServerValidator) ValidateCreate(ctx context.Context, server *teraskyv1alpha1.ConversionWebhookServer) (admission.Warnings, error) {
+	if err := teraskyv1alpha1.ValidateWebhookServerExtraArgs(server.Spec.ExtraArgs); err != nil {
+		return nil, err
+	}
 	return nil, v.checkDefault(ctx, server)
 }
 
 func (v *ConversionWebhookServerValidator) ValidateUpdate(ctx context.Context, _, newServer *teraskyv1alpha1.ConversionWebhookServer) (admission.Warnings, error) {
+	if err := teraskyv1alpha1.ValidateWebhookServerExtraArgs(newServer.Spec.ExtraArgs); err != nil {
+		return nil, err
+	}
 	return nil, v.checkDefault(ctx, newServer)
 }
 

--- a/internal/webhook/conversionwebhookserver_webhook_test.go
+++ b/internal/webhook/conversionwebhookserver_webhook_test.go
@@ -34,6 +34,37 @@ func TestConversionWebhookServerValidator_CheckDefault_NoConflictWhenNotDefault(
 	}
 }
 
+func TestConversionWebhookServerValidator_ExtraArgs_RejectsManagedFlag(t *testing.T) {
+	c := newFakeClient().Build()
+	v := &ConversionWebhookServerValidator{Client: c}
+	server := &teraskyv1alpha1.ConversionWebhookServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "srv"},
+		Spec: teraskyv1alpha1.ConversionWebhookServerSpec{
+			ExtraArgs: []string{"--webhook-server-name=evil"},
+		},
+	}
+	if _, err := v.ValidateCreate(context.Background(), server); err == nil {
+		t.Fatal("expected ExtraArgs naming a managed flag to be rejected")
+	}
+	if _, err := v.ValidateUpdate(context.Background(), server, server); err == nil {
+		t.Fatal("expected ExtraArgs naming a managed flag to be rejected on update")
+	}
+}
+
+func TestConversionWebhookServerValidator_ExtraArgs_AllowsOptional(t *testing.T) {
+	c := newFakeClient().Build()
+	v := &ConversionWebhookServerValidator{Client: c}
+	server := &teraskyv1alpha1.ConversionWebhookServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "srv"},
+		Spec: teraskyv1alpha1.ConversionWebhookServerSpec{
+			ExtraArgs: []string{"--cert-reload-interval=1m", "--zap-devel", "true"},
+		},
+	}
+	if _, err := v.ValidateCreate(context.Background(), server); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestConversionWebhookServerValidator_CheckDefault_FirstDefaultAllowed(t *testing.T) {
 	c := newFakeClient().Build()
 	v := &ConversionWebhookServerValidator{Client: c}


### PR DESCRIPTION
## Summary
- Add `ConversionWebhookServer.spec.extraArgs` and append those args after operator-managed webhook-server flags in the Deployment builder.
- Remove the dead Helm `conversionWebhookServer.extraArgs` values key; document that CWS pods (including `extraArgs`) are configured via the CR.

Closes #12

## Test plan
- [x] `make generate manifests helm-sync`
- [x] `make test` (includes `TestCWSReconcile_ExtraArgs_AppendedToDeployment`)
- [x] `make test-e2e`
- [ ] CI green on this PR / stack