### PR TITLE
chore: CodeRabbit auto-review PRs targeting any base branch

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+# Review PRs targeting any base branch (not just the repo default).
+# Needed for gh-stack layered PRs whose base is the branch below them.
+reviews:
+  auto_review:
+    base_branches:
+      - ".*"


### PR DESCRIPTION
## Summary
- Add `.coderabbit.yaml` with `reviews.auto_review.base_branches: [\".*\"]` so CodeRabbit reviews PRs whose base is not the repo default branch.
- Needed for `gh stack` layered PRs (each layer bases on the branch below it); without this, only the bottom PR against `main` gets automatic review.

Takes effect once this config lands on the default branch. Existing open stack PRs were already manually triggered with `@coderabbitai full review`.

## Test plan
- [x] `coderabbit config validate .coderabbit.yaml`
- [ ] After merge to `main`, open a PR targeting a non-default branch and confirm CodeRabbit auto-reviews it