### PR TITLE
Phase 1: Security hardening

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,43 @@
+# Security Policy
+
+## Supported versions
+
+This project is currently in **alpha** (`v1alpha1` APIs). Security fixes
+are applied to the latest published release on the default branch; older
+alpha tags are not backported unless explicitly called out in a release
+advisory.
+
+## Reporting a vulnerability
+
+Please **do not** open a public GitHub issue for security reports.
+
+Report vulnerabilities privately via GitHub Security Advisories for this
+repository:
+
+https://github.com/TeraSky-OSS/declarative-conversion-operator/security/advisories/new
+
+Include a description of the issue, steps to reproduce, affected versions
+(or commit), and any suggested fix if you have one. We will acknowledge
+receipt and work with you on a coordinated disclosure timeline.
+
+## Security model (summary)
+
+- **Conversion webhook TLS.** Each `ConversionWebhookServer` gets a
+  cert-manager `Certificate`; the operator mounts the issued Secret into
+  webhook-server pods and refreshes the target XRD/CRD `caBundle` when the
+  Secret rotates. cert-manager's CA injector is not used for XRD/CRD
+  conversion webhook config (those resources are not supported injection
+  targets).
+- **Admission webhook TLS.** The manager's own validating webhook (for
+  this operator's CRDs) uses a separate cert-manager Certificate templated
+  by the Helm chart.
+- **Pod security.** Manager and webhook-server pods run under Pod Security
+  Standards `restricted`-compatible settings — see
+  [Pod security posture](docs/security/pod-security.md).
+- **Network.** Opt-in NetworkPolicies can lock metrics scrape sources and
+  deny non-webhook ingress — see [Metrics trust boundary](docs/security/metrics.md).
+- **RBAC.** The manager can patch XRDs/CRDs (to wire conversion webhooks);
+  webhook-server ServiceAccounts are read/watch-only. Full verb/resource
+  justifications: [RBAC blast radius](docs/security/rbac.md).
+- **Supply chain.** Release images are signed (cosign) with SBOMs. Prefer
+  pinning images by digest — see chart `image.*.digest` values.

--- a/api/v1alpha1/conversionwebhookserver_types.go
+++ b/api/v1alpha1/conversionwebhookserver_types.go
@@ -30,6 +30,11 @@ type ImageSpec struct {
 	Repository string `json:"repository,omitempty"`
 	// +optional
 	Tag string `json:"tag,omitempty"`
+	// Digest, when set, pins the image by content digest and takes
+	// precedence over Tag (rendered as repository@digest). Prefer a full
+	// digest reference such as "sha256:...".
+	// +optional
+	Digest string `json:"digest,omitempty"`
 	// +optional
 	PullPolicy corev1.PullPolicy `json:"pullPolicy,omitempty"`
 }

--- a/charts/declarative-conversion-operator/crds/terasky.com_conversionwebhookservers.yaml
+++ b/charts/declarative-conversion-operator/crds/terasky.com_conversionwebhookservers.yaml
@@ -1047,6 +1047,12 @@ spec:
                   instance's pods. Leave unset to use the operator's own default (set via
                   Helm values / manager flags).
                 properties:
+                  digest:
+                    description: |-
+                      Digest, when set, pins the image by content digest and takes
+                      precedence over Tag (rendered as repository@digest). Prefer a full
+                      digest reference such as "sha256:...".
+                    type: string
                   pullPolicy:
                     description: PullPolicy describes a policy for if/when to pull
                       a container image

--- a/charts/declarative-conversion-operator/templates/_helpers.tpl
+++ b/charts/declarative-conversion-operator/templates/_helpers.tpl
@@ -68,6 +68,31 @@ spec.namespace is left unset — defaults to the release namespace.
 {{- end }}
 
 {{/*
+Manager container image. Prefer digest pinning when image.manager.digest is set.
+*/}}
+{{- define "declarative-conversion-operator.managerImage" -}}
+{{- $repo := printf "%s/%s" .Values.image.registry .Values.image.manager.repository -}}
+{{- if .Values.image.manager.digest -}}
+{{- printf "%s@%s" $repo .Values.image.manager.digest -}}
+{{- else -}}
+{{- printf "%s:%s" $repo (.Values.image.manager.tag | default .Chart.AppVersion) -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Webhook-server container image (also passed to the manager as --default-webhook-server-image).
+Prefer digest pinning when image.webhookServer.digest is set.
+*/}}
+{{- define "declarative-conversion-operator.webhookServerImage" -}}
+{{- $repo := printf "%s/%s" .Values.image.registry .Values.image.webhookServer.repository -}}
+{{- if .Values.image.webhookServer.digest -}}
+{{- printf "%s@%s" $repo .Values.image.webhookServer.digest -}}
+{{- else -}}
+{{- printf "%s:%s" $repo (.Values.image.webhookServer.tag | default .Chart.AppVersion) -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 The manager's own admission-webhook Service name (referenced by both the
 Certificate and the ValidatingWebhookConfiguration).
 */}}

--- a/charts/declarative-conversion-operator/templates/conversion-webhook-server/conversionwebhookserver.yaml
+++ b/charts/declarative-conversion-operator/templates/conversion-webhook-server/conversionwebhookserver.yaml
@@ -23,7 +23,11 @@ spec:
   {{- end }}
   image:
     repository: {{ .Values.image.registry }}/{{ .Values.image.webhookServer.repository }}
+    {{- if .Values.image.webhookServer.digest }}
+    digest: {{ .Values.image.webhookServer.digest | quote }}
+    {{- else }}
     tag: {{ .Values.image.webhookServer.tag | default .Chart.AppVersion | quote }}
+    {{- end }}
     pullPolicy: {{ .Values.image.pullPolicy }}
   resources:
     {{- toYaml .Values.conversionWebhookServer.resources | nindent 4 }}

--- a/charts/declarative-conversion-operator/templates/manager/deployment.yaml
+++ b/charts/declarative-conversion-operator/templates/manager/deployment.yaml
@@ -21,8 +21,14 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      # PSS restricted — kept identical to ConversionWebhookServer pods
+      # (see docs/security/pod-security.md). Distroless nonroot USER 65532.
       securityContext:
         runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: manager
           image: "{{ .Values.image.registry }}/{{ .Values.image.manager.repository }}:{{ .Values.image.manager.tag | default .Chart.AppVersion }}"
@@ -64,22 +70,32 @@ spec:
             periodSeconds: 10
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
             capabilities:
               drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
           resources:
             {{- toYaml .Values.manager.resources | nindent 12 }}
-          {{- if .Values.admissionWebhook.enabled }}
           volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            {{- if .Values.admissionWebhook.enabled }}
             - name: webhook-certs
               mountPath: /tmp/k8s-webhook-server/serving-certs
               readOnly: true
-          {{- end }}
-      {{- if .Values.admissionWebhook.enabled }}
+            {{- end }}
       volumes:
+        - name: tmp
+          emptyDir: {}
+        {{- if .Values.admissionWebhook.enabled }}
         - name: webhook-certs
           secret:
             secretName: {{ include "declarative-conversion-operator.fullname" . }}-webhook-cert
-      {{- end }}
+        {{- end }}
       {{- with .Values.manager.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/declarative-conversion-operator/templates/manager/deployment.yaml
+++ b/charts/declarative-conversion-operator/templates/manager/deployment.yaml
@@ -22,11 +22,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       # PSS restricted — kept identical to ConversionWebhookServer pods
-      # (see docs/security/pod-security.md). Distroless nonroot USER 65532.
+      # (see docs/security/pod-security.md). runAsUser unset so custom
+      # image USER is honored; runAsNonRoot rejects root.
       securityContext:
         runAsNonRoot: true
-        runAsUser: 65532
-        runAsGroup: 65532
         seccompProfile:
           type: RuntimeDefault
       containers:
@@ -72,8 +71,6 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
             runAsNonRoot: true
-            runAsUser: 65532
-            runAsGroup: 65532
             capabilities:
               drop: ["ALL"]
             seccompProfile:

--- a/charts/declarative-conversion-operator/templates/manager/deployment.yaml
+++ b/charts/declarative-conversion-operator/templates/manager/deployment.yaml
@@ -31,7 +31,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: manager
-          image: "{{ .Values.image.registry }}/{{ .Values.image.manager.repository }}:{{ .Values.image.manager.tag | default .Chart.AppVersion }}"
+          image: "{{ include "declarative-conversion-operator.managerImage" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - --health-probe-bind-address=:8081
@@ -39,7 +39,7 @@ spec:
             {{- if .Values.manager.leaderElection.enabled }}
             - --leader-elect
             {{- end }}
-            - --default-webhook-server-image={{ .Values.image.registry }}/{{ .Values.image.webhookServer.repository }}:{{ .Values.image.webhookServer.tag | default .Chart.AppVersion }}
+            - --default-webhook-server-image={{ include "declarative-conversion-operator.webhookServerImage" . }}
             - --enable-xrd-support={{ .Values.features.crossplane.enabled }}
             - --enable-crd-support={{ .Values.features.nativeCRD.enabled }}
             {{- with .Values.manager.extraArgs }}

--- a/charts/declarative-conversion-operator/templates/networkpolicy/networkpolicy.yaml
+++ b/charts/declarative-conversion-operator/templates/networkpolicy/networkpolicy.yaml
@@ -1,0 +1,76 @@
+{{- if .Values.networkPolicy.enabled }}
+# Manager: admit conversion/admission webhook traffic + metrics scrapes;
+# deny everything else to the manager pods.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "declarative-conversion-operator.fullname" . }}-manager
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "declarative-conversion-operator.labels" . | nindent 4 }}
+    control-plane: controller-manager
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "declarative-conversion-operator.managerSelectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+  ingress:
+    # Admission webhook (apiserver → manager). No `from` so the control-plane
+    # can reach the webhook regardless of how apiserver is networked.
+    - ports:
+        - protocol: TCP
+          port: 9443
+    # Health probes from kubelet use the pod network; allow probes port
+    # similarly without a from-selector.
+    - ports:
+        - protocol: TCP
+          port: 8081
+    {{- if .Values.metrics.enabled }}
+    # Metrics scrape. Restrict with networkPolicy.metrics.allowedPeers when set;
+    # empty allowedPeers keeps metrics reachable from any in-cluster source
+    # while still locking non-metrics ports (see docs/security/metrics.md).
+    - ports:
+        - protocol: TCP
+          port: 8080
+      {{- with .Values.networkPolicy.metrics.allowedPeers }}
+      from:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- end }}
+---
+# ConversionWebhookServer pods (default instance when chart creates one).
+# Extra CWS instances need their own NetworkPolicy or a broader selector.
+{{- if .Values.conversionWebhookServer.create }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "declarative-conversion-operator.fullname" . }}-webhook-server
+  namespace: {{ .Values.conversionWebhookServer.namespace | default .Release.Namespace }}
+  labels:
+    {{- include "declarative-conversion-operator.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: declarative-conversion-webhook-server
+      app.kubernetes.io/instance: {{ .Values.conversionWebhookServer.name }}
+      app.kubernetes.io/managed-by: declarative-conversion-operator
+  policyTypes:
+    - Ingress
+  ingress:
+    # CRD/XRD conversion webhook (apiserver → CWS). No `from` — same reason
+    # as the manager admission webhook above.
+    - ports:
+        - protocol: TCP
+          port: 9443
+    {{- if .Values.metrics.enabled }}
+    - ports:
+        - protocol: TCP
+          port: 8443
+      {{- with .Values.networkPolicy.metrics.allowedPeers }}
+      from:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/declarative-conversion-operator/templates/networkpolicy/networkpolicy.yaml
+++ b/charts/declarative-conversion-operator/templates/networkpolicy/networkpolicy.yaml
@@ -63,14 +63,14 @@ spec:
     - ports:
         - protocol: TCP
           port: 9443
-    {{- if .Values.metrics.enabled }}
+    # Health probes (/healthz, /readyz) and metrics share plain-HTTP port
+    # 8443 on the webhook-server. Always admit without a from-selector so
+    # kubelet probes work on CNIs that enforce NetworkPolicy for node→pod
+    # traffic. Peer-restricting this shared port would break probes; see
+    # docs/security/metrics.md. Manager can peer-restrict metrics because
+    # its probe port (8081) is separate from metrics (8080).
     - ports:
         - protocol: TCP
           port: 8443
-      {{- with .Values.networkPolicy.metrics.allowedPeers }}
-      from:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-    {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/declarative-conversion-operator/values.yaml
+++ b/charts/declarative-conversion-operator/values.yaml
@@ -152,13 +152,14 @@ metrics:
 
 # Opt-in NetworkPolicies for manager + default ConversionWebhookServer pods.
 # Off by default so existing installs see no behavior change. When enabled,
-# non-webhook/non-metrics ingress is denied; see docs/security/metrics.md.
+# non-webhook/non-probe ingress is denied; see docs/security/metrics.md.
 networkPolicy:
   enabled: false
   metrics:
     # List of networking.k8s.io NetworkPolicyPeer objects allowed to scrape
-    # metrics ports. Empty = any source may scrape metrics (webhook ports
-    # remain open to the apiserver either way).
+    # the *manager* metrics port (8080). Empty = any source may scrape.
+    # Does not apply to CWS port 8443 (probes share that port). Webhook
+    # ports remain open to the apiserver either way.
     # Example:
     #   allowedPeers:
     #     - namespaceSelector:

--- a/charts/declarative-conversion-operator/values.yaml
+++ b/charts/declarative-conversion-operator/values.yaml
@@ -145,3 +145,22 @@ metrics:
   prometheusRule:
     enabled: false
     labels: {}
+
+# Opt-in NetworkPolicies for manager + default ConversionWebhookServer pods.
+# Off by default so existing installs see no behavior change. When enabled,
+# non-webhook/non-metrics ingress is denied; see docs/security/metrics.md.
+networkPolicy:
+  enabled: false
+  metrics:
+    # List of networking.k8s.io NetworkPolicyPeer objects allowed to scrape
+    # metrics ports. Empty = any source may scrape metrics (webhook ports
+    # remain open to the apiserver either way).
+    # Example:
+    #   allowedPeers:
+    #     - namespaceSelector:
+    #         matchLabels:
+    #           kubernetes.io/metadata.name: monitoring
+    #       podSelector:
+    #         matchLabels:
+    #           app.kubernetes.io/name: prometheus
+    allowedPeers: []

--- a/charts/declarative-conversion-operator/values.yaml
+++ b/charts/declarative-conversion-operator/values.yaml
@@ -7,9 +7,13 @@ image:
   manager:
     repository: terasky-oss/declarative-conversion-operator
     tag: ""
+    # Optional content digest (e.g. sha256:...). When set, pins the image by
+    # digest instead of tag (repository@digest).
+    digest: ""
   webhookServer:
     repository: terasky-oss/declarative-conversion-webhook-server
     tag: ""
+    digest: ""
   pullPolicy: IfNotPresent
 
 # CRDs are installed from the crds/ directory (Helm's built-in convention):

--- a/config/crd/bases/terasky.com_conversionwebhookservers.yaml
+++ b/config/crd/bases/terasky.com_conversionwebhookservers.yaml
@@ -1047,6 +1047,12 @@ spec:
                   instance's pods. Leave unset to use the operator's own default (set via
                   Helm values / manager flags).
                 properties:
+                  digest:
+                    description: |-
+                      Digest, when set, pins the image by content digest and takes
+                      precedence over Tag (rendered as repository@digest). Prefer a full
+                      digest reference such as "sha256:...".
+                    type: string
                   pullPolicy:
                     description: PullPolicy describes a policy for if/when to pull
                       a container image

--- a/config/manager/deployment.yaml
+++ b/config/manager/deployment.yaml
@@ -19,8 +19,6 @@ spec:
       serviceAccountName: manager
       securityContext:
         runAsNonRoot: true
-        runAsUser: 65532
-        runAsGroup: 65532
         seccompProfile:
           type: RuntimeDefault
       containers:
@@ -61,8 +59,6 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
             runAsNonRoot: true
-            runAsUser: 65532
-            runAsGroup: 65532
             capabilities:
               drop: ["ALL"]
             seccompProfile:

--- a/config/manager/deployment.yaml
+++ b/config/manager/deployment.yaml
@@ -19,6 +19,10 @@ spec:
       serviceAccountName: manager
       securityContext:
         runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: manager
           image: controller:latest
@@ -55,13 +59,23 @@ spec:
               memory: 256Mi
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
             capabilities:
               drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
           volumeMounts:
+            - name: tmp
+              mountPath: /tmp
             - name: webhook-certs
               mountPath: /tmp/k8s-webhook-server/serving-certs
               readOnly: true
       volumes:
+        - name: tmp
+          emptyDir: {}
         - name: webhook-certs
           secret:
             secretName: webhook-server-cert

--- a/docs/configuration/conversionwebhookserver.md
+++ b/docs/configuration/conversionwebhookserver.md
@@ -30,7 +30,7 @@ spec:
 | `namespace` | Where this instance's owned resources live. Defaults to the operator's install namespace. |
 | `replicas` | Fixed replica count. Mutually exclusive with `autoscaling` — once autoscaling is set, the HPA owns the replica count and this controller stops driving it directly. |
 | `autoscaling.{minReplicas,maxReplicas,targetCPUUtilizationPercentage}` | Creates a `HorizontalPodAutoscaler` for this instance instead of a fixed count. |
-| `image.{repository,tag,pullPolicy}` | Overrides the webhook-server image for this instance. Omit to use the operator's own default (set via Helm `image.webhookServer.*` / a manager flag). |
+| `image.{repository,tag,digest,pullPolicy}` | Overrides the webhook-server image for this instance. Omit to use the operator's own default (set via Helm `image.webhookServer.*` / a manager flag). When `digest` is set it takes precedence over `tag` (`repository@digest`). |
 | `resources`, `nodeSelector`, `tolerations`, `affinity`, `priorityClassName`, `serviceAccountName` | Standard Kubernetes pod-scheduling knobs, applied to this instance's Deployment. |
 | `extraArgs` | Additional container arguments appended after operator-managed flags (`--webhook-server-name`, `--tls-cert-dir`, bind addresses, feature toggles). For optional webhook-server flags (e.g. `--cert-reload-interval`, zap options). Admission and reconcile reject ExtraArgs that name those managed flags. |
 | `certificate.issuerRef` | The cert-manager `Issuer`/`ClusterIssuer` for this instance's webhook TLS certificate. `certificate.dnsNames`, `.duration`, `.renewBefore` are also available. |

--- a/docs/security/metrics.md
+++ b/docs/security/metrics.md
@@ -11,10 +11,12 @@ HTTP metrics port in-cluster:
 | Webhook-server | `8443` | `*-webhook-server` (`metrics` port) |
 
 With no NetworkPolicy (the chart default), any pod that can reach the
-install namespace can scrape these endpoints. That is fine for many
-clusters, but it is **not** a documented trust boundary — it only happens
-to be true when your CNI/default-deny posture already blocks cross-pod
-traffic.
+component's namespace can scrape these endpoints. The manager uses the
+Helm release namespace; a ConversionWebhookServer may use a different
+namespace via `conversionWebhookServer.namespace` /
+`spec.namespace`. That is fine for many clusters, but it is **not** a
+documented trust boundary — it only happens to be true when your
+CNI/default-deny posture already blocks cross-pod traffic.
 
 ## Locking metrics down (NetworkPolicy)
 

--- a/docs/security/metrics.md
+++ b/docs/security/metrics.md
@@ -1,0 +1,55 @@
+# Metrics trust boundary
+
+## Default exposure
+
+Both the **manager** and each **ConversionWebhookServer** replica expose an
+HTTP metrics port in-cluster:
+
+| Component | Port | Service |
+|---|---|---|
+| Manager | `8080` | `*-manager-metrics` |
+| Webhook-server | `8443` | `*-webhook-server` (`metrics` port) |
+
+With no NetworkPolicy (the chart default), any pod that can reach the
+install namespace can scrape these endpoints. That is fine for many
+clusters, but it is **not** a documented trust boundary — it only happens
+to be true when your CNI/default-deny posture already blocks cross-pod
+traffic.
+
+## Locking metrics down (NetworkPolicy)
+
+Set `networkPolicy.enabled=true` to deny ingress to manager and default
+CWS pods except:
+
+1. **Webhook ports** (`9443`) — left without a `from` selector so the
+   apiserver can always reach conversion/admission webhooks.
+2. **Probe port** on the manager (`8081`) — same rationale for kubelet.
+3. **Metrics ports** — optionally restricted via
+   `networkPolicy.metrics.allowedPeers` (a list of
+   [`NetworkPolicyPeer`](https://kubernetes.io/docs/reference/kubernetes-api/policy-resources/network-policy-v1/#NetworkPolicyPeer)
+   objects).
+
+Example — only Prometheus in the `monitoring` namespace may scrape:
+
+```yaml
+networkPolicy:
+  enabled: true
+  metrics:
+    allowedPeers:
+      - namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: monitoring
+        podSelector:
+          matchLabels:
+            app.kubernetes.io/name: prometheus
+```
+
+With `allowedPeers: []` (the default when NetworkPolicy is on), metrics
+remain reachable from any in-cluster source while non-metrics ports stay
+locked to the webhook/probe rules above.
+
+## Future hardening
+
+Authenticating scrapers with `kube-rbac-proxy` or controller-runtime's
+secure-metrics serving is a useful next step for clusters that cannot
+rely on NetworkPolicy alone. File an issue if your environment requires it.

--- a/docs/security/metrics.md
+++ b/docs/security/metrics.md
@@ -24,12 +24,17 @@ CWS pods except:
 1. **Webhook ports** (`9443`) — left without a `from` selector so the
    apiserver can always reach conversion/admission webhooks.
 2. **Probe port** on the manager (`8081`) — same rationale for kubelet.
-3. **Metrics ports** — optionally restricted via
+3. **Manager metrics** (`8080`) — optionally restricted via
    `networkPolicy.metrics.allowedPeers` (a list of
    [`NetworkPolicyPeer`](https://kubernetes.io/docs/reference/kubernetes-api/policy-resources/network-policy-v1/#NetworkPolicyPeer)
    objects).
+4. **Webhook-server plain-HTTP port** (`8443`) — always admitted without a
+   `from` selector. Probes (`/healthz`, `/readyz`) and metrics share this
+   port, so peer-restricting it would break kubelet health checks on CNIs
+   that enforce NetworkPolicy for node→pod traffic.
 
-Example — only Prometheus in the `monitoring` namespace may scrape:
+Example — only Prometheus in the `monitoring` namespace may scrape **manager**
+metrics:
 
 ```yaml
 networkPolicy:
@@ -44,12 +49,15 @@ networkPolicy:
             app.kubernetes.io/name: prometheus
 ```
 
-With `allowedPeers: []` (the default when NetworkPolicy is on), metrics
-remain reachable from any in-cluster source while non-metrics ports stay
-locked to the webhook/probe rules above.
+With `allowedPeers: []` (the default when NetworkPolicy is on), manager
+metrics remain reachable from any in-cluster source while non-metrics ports
+stay locked to the webhook/probe rules above. CWS `8443` stays open either
+way for the probe reason above.
 
 ## Future hardening
 
+Serving webhook-server probes on a dedicated port (mirroring the manager's
+`8081` / `8080` split) would let NetworkPolicy peer-restrict CWS metrics.
 Authenticating scrapers with `kube-rbac-proxy` or controller-runtime's
-secure-metrics serving is a useful next step for clusters that cannot
+secure-metrics serving is another useful next step for clusters that cannot
 rely on NetworkPolicy alone. File an issue if your environment requires it.

--- a/docs/security/pod-security.md
+++ b/docs/security/pod-security.md
@@ -3,18 +3,20 @@
 Both Deployments this operator runs — the **manager** (Helm-templated) and
 each **ConversionWebhookServer** webhook-server replica (built in Go by the
 controller) — use the same Pod Security Standards `restricted`-compatible
-`securityContext`. The images are `gcr.io/distroless/static:nonroot`
-(`USER 65532:65532`).
+`securityContext`. Default images are `gcr.io/distroless/static:nonroot`
+(`USER 65532:65532`). Manifests set `runAsNonRoot: true` but do **not**
+pin `runAsUser`/`runAsGroup`, so a custom image's non-root `USER` is
+honored (root images fail closed under `runAsNonRoot`).
 
 | Setting | Manager | Webhook-server (CWS) |
 |---|---|---|
 | Pod `runAsNonRoot` | `true` | `true` |
-| Pod `runAsUser` / `runAsGroup` | `65532` | `65532` |
+| Pod `runAsUser` / `runAsGroup` | unset (image `USER`) | unset (image `USER`) |
 | Pod `seccompProfile.type` | `RuntimeDefault` | `RuntimeDefault` |
 | Container `allowPrivilegeEscalation` | `false` | `false` |
 | Container `capabilities.drop` | `[ALL]` | `[ALL]` |
 | Container `readOnlyRootFilesystem` | `true` | `true` |
-| Container `runAsUser` / `runAsGroup` | `65532` | `65532` |
+| Container `runAsNonRoot` | `true` | `true` |
 | Scratch volume | `emptyDir` at `/tmp` | `emptyDir` at `/tmp` |
 | TLS certs | Secret mount under `/tmp/k8s-webhook-server/serving-certs` | Secret mount at `/tls` (read-only) |
 

--- a/docs/security/pod-security.md
+++ b/docs/security/pod-security.md
@@ -1,0 +1,29 @@
+# Pod security posture
+
+Both Deployments this operator runs — the **manager** (Helm-templated) and
+each **ConversionWebhookServer** webhook-server replica (built in Go by the
+controller) — use the same Pod Security Standards `restricted`-compatible
+`securityContext`. The images are `gcr.io/distroless/static:nonroot`
+(`USER 65532:65532`).
+
+| Setting | Manager | Webhook-server (CWS) |
+|---|---|---|
+| Pod `runAsNonRoot` | `true` | `true` |
+| Pod `runAsUser` / `runAsGroup` | `65532` | `65532` |
+| Pod `seccompProfile.type` | `RuntimeDefault` | `RuntimeDefault` |
+| Container `allowPrivilegeEscalation` | `false` | `false` |
+| Container `capabilities.drop` | `[ALL]` | `[ALL]` |
+| Container `readOnlyRootFilesystem` | `true` | `true` |
+| Container `runAsUser` / `runAsGroup` | `65532` | `65532` |
+| Scratch volume | `emptyDir` at `/tmp` | `emptyDir` at `/tmp` |
+| TLS certs | Secret mount under `/tmp/k8s-webhook-server/serving-certs` | Secret mount at `/tls` (read-only) |
+
+The only intentional difference is **where TLS material is mounted**: the
+manager's kubebuilder admission webhook expects certs under
+`/tmp/k8s-webhook-server/serving-certs`; the conversion webhook-server
+binary is passed `--tls-cert-dir=/tls`.
+
+## Where this is set
+
+- Manager: `charts/declarative-conversion-operator/templates/manager/deployment.yaml` (and the kustomize twin in `config/manager/deployment.yaml`)
+- Webhook-server: `internal/controller/conversionwebhookserver_controller.go` (`reconcileDeployment`)

--- a/docs/security/rbac.md
+++ b/docs/security/rbac.md
@@ -1,9 +1,10 @@
 # RBAC blast radius
 
-This operator installs two cluster-scoped ServiceAccounts. Both are
-cluster-scoped in effect (their Roles are `ClusterRole`s) because the
-CRDs they manage — `XRDConversionConfig`, `CRDConversionConfig`,
-`ConversionWebhookServer`, plus target XRDs/CRDs — are cluster-scoped.
+This operator installs two **namespace-scoped** ServiceAccounts bound to
+`ClusterRole`s (via `ClusterRoleBinding`s). Those bindings grant
+cluster-wide permissions because the CRDs they manage —
+`XRDConversionConfig`, `CRDConversionConfig`, `ConversionWebhookServer`,
+plus target XRDs/CRDs — are cluster-scoped.
 
 Source of truth for the chart install path:
 `charts/declarative-conversion-operator/templates/rbac/clusterrole.yaml`.
@@ -15,10 +16,13 @@ Used by the operator manager Deployment. It **mutates** target XRDs/CRDs
 to wire (and unwind) conversion webhook configuration — that is the
 highest-privilege action this operator takes.
 
+Unless noted, list/watch grants below apply to **all** objects of that
+resource type in scope (no name/namespace restriction in the ClusterRole).
+
 | API group | Resource | Verbs | Why |
 |---|---|---|---|
 | `""` | `events` | `create`, `patch` | Emit reconcile events. |
-| `""` | `secrets` | `get`, `list`, `watch` | Read cert-manager-issued TLS Secrets so the controller can refresh XRD/CRD `caBundle`s on rotation. |
+| `""` | `secrets` | `get`, `list`, `watch` | Intended use: read cert-manager-issued TLS Secrets so the controller can refresh XRD/CRD `caBundle`s on rotation. **Granted scope:** all Secrets cluster-wide (not limited to cert-manager or operator-owned names). |
 | `""` | `services` | `create`, `delete`, `get`, `list`, `patch`, `update`, `watch` | Own the Service in front of each ConversionWebhookServer. |
 | `apiextensions.crossplane.io` | `compositeresourcedefinitions` | `get`, `list`, `patch`, `watch` | Read XRD schemas for validation; **patch** `spec.conversion` to attach/detach the conversion webhook. |
 | `apiextensions.k8s.io` | `customresourcedefinitions` | `get`, `list`, `patch`, `watch` | Same for native CRDs when native-CRD support is enabled. |
@@ -27,7 +31,7 @@ highest-privilege action this operator takes.
 | `cert-manager.io` | `certificates` | `create`, `delete`, `get`, `list`, `patch`, `update`, `watch` | Own the Certificate for each ConversionWebhookServer. |
 | `policy` | `poddisruptionbudgets` | `create`, `delete`, `get`, `list`, `patch`, `update`, `watch` | Own optional PDBs for ConversionWebhookServer instances. |
 | `coordination.k8s.io` | `leases` | `get`, `list`, `watch`, `create`, `update`, `patch`, `delete` | Leader election for the manager. |
-| `admissionregistration.k8s.io` | `validatingwebhookconfigurations` | `get`, `list`, `watch` | Observe this operator's own admission webhook configuration. |
+| `admissionregistration.k8s.io` | `validatingwebhookconfigurations` | `get`, `list`, `watch` | Intended use: observe this operator's admission webhook configuration. **Granted scope:** all ValidatingWebhookConfigurations cluster-wide. |
 | `terasky.com` | `conversionwebhookservers`, `crdconversionconfigs`, `xrdconversionconfigs` | `create`, `delete`, `get`, `list`, `patch`, `update`, `watch` | Reconcile this operator's CRDs. |
 | `terasky.com` | `*/finalizers` | `update` | Safe-delete / safe-revert finalizers. |
 | `terasky.com` | `*/status` | `get`, `patch`, `update` | Write status/conditions. |
@@ -60,6 +64,6 @@ No access to Secrets, no write verbs, no ability to patch XRDs/CRDs.
 
 ## Related docs
 
-- [SECURITY.md](../../SECURITY.md) — reporting process and high-level model
+- [SECURITY.md](https://github.com/TeraSky-OSS/declarative-conversion-operator/blob/main/SECURITY.md) — reporting process and high-level model
 - [Pod security posture](pod-security.md)
 - [Metrics trust boundary](metrics.md)

--- a/docs/security/rbac.md
+++ b/docs/security/rbac.md
@@ -1,0 +1,65 @@
+# RBAC blast radius
+
+This operator installs two cluster-scoped ServiceAccounts. Both are
+cluster-scoped in effect (their Roles are `ClusterRole`s) because the
+CRDs they manage — `XRDConversionConfig`, `CRDConversionConfig`,
+`ConversionWebhookServer`, plus target XRDs/CRDs — are cluster-scoped.
+
+Source of truth for the chart install path:
+`charts/declarative-conversion-operator/templates/rbac/clusterrole.yaml`.
+The kustomize twin lives under `config/rbac/`.
+
+## Manager ServiceAccount
+
+Used by the operator manager Deployment. It **mutates** target XRDs/CRDs
+to wire (and unwind) conversion webhook configuration — that is the
+highest-privilege action this operator takes.
+
+| API group | Resource | Verbs | Why |
+|---|---|---|---|
+| `""` | `events` | `create`, `patch` | Emit reconcile events. |
+| `""` | `secrets` | `get`, `list`, `watch` | Read cert-manager-issued TLS Secrets so the controller can refresh XRD/CRD `caBundle`s on rotation. |
+| `""` | `services` | `create`, `delete`, `get`, `list`, `patch`, `update`, `watch` | Own the Service in front of each ConversionWebhookServer. |
+| `apiextensions.crossplane.io` | `compositeresourcedefinitions` | `get`, `list`, `patch`, `watch` | Read XRD schemas for validation; **patch** `spec.conversion` to attach/detach the conversion webhook. |
+| `apiextensions.k8s.io` | `customresourcedefinitions` | `get`, `list`, `patch`, `watch` | Same for native CRDs when native-CRD support is enabled. |
+| `apps` | `deployments` | `create`, `delete`, `get`, `list`, `patch`, `update`, `watch` | Own each ConversionWebhookServer's Deployment. |
+| `autoscaling` | `horizontalpodautoscalers` | `create`, `delete`, `get`, `list`, `patch`, `update`, `watch` | Own optional HPAs for ConversionWebhookServer instances. |
+| `cert-manager.io` | `certificates` | `create`, `delete`, `get`, `list`, `patch`, `update`, `watch` | Own the Certificate for each ConversionWebhookServer. |
+| `policy` | `poddisruptionbudgets` | `create`, `delete`, `get`, `list`, `patch`, `update`, `watch` | Own optional PDBs for ConversionWebhookServer instances. |
+| `coordination.k8s.io` | `leases` | `get`, `list`, `watch`, `create`, `update`, `patch`, `delete` | Leader election for the manager. |
+| `admissionregistration.k8s.io` | `validatingwebhookconfigurations` | `get`, `list`, `watch` | Observe this operator's own admission webhook configuration. |
+| `terasky.com` | `conversionwebhookservers`, `crdconversionconfigs`, `xrdconversionconfigs` | `create`, `delete`, `get`, `list`, `patch`, `update`, `watch` | Reconcile this operator's CRDs. |
+| `terasky.com` | `*/finalizers` | `update` | Safe-delete / safe-revert finalizers. |
+| `terasky.com` | `*/status` | `get`, `patch`, `update` | Write status/conditions. |
+
+### Why XRD/CRD `patch` is required
+
+Kubernetes has no narrower verb for "set `spec.conversion` only." Patching
+an XRD/CRD is therefore the blast-radius hot spot: a compromised manager
+could in principle alter other fields on those resources. Mitigations in
+practice:
+
+- The controller only SSA-patches the conversion webhook fields it owns.
+- Configs are admission-validated before any patch.
+- Deletion is finalizer-gated when more than one version is still served.
+
+## Webhook-server ServiceAccount
+
+Used by every `ConversionWebhookServer` pod. **Read/watch only** — the
+webhook-server binary never mutates cluster state. Each replica runs its
+own informers so it can compile conversion plans without depending on the
+manager at request time.
+
+| API group | Resource | Verbs | Why |
+|---|---|---|---|
+| `terasky.com` | `xrdconversionconfigs`, `crdconversionconfigs`, `conversionwebhookservers` | `get`, `list`, `watch` | Discover assigned configs and the owning server. |
+| `apiextensions.crossplane.io` | `compositeresourcedefinitions` | `get`, `list`, `watch` | Read live XRD schemas to (re)compile plans. |
+| `apiextensions.k8s.io` | `customresourcedefinitions` | `get`, `list`, `watch` | Same for native CRDs. |
+
+No access to Secrets, no write verbs, no ability to patch XRDs/CRDs.
+
+## Related docs
+
+- [SECURITY.md](../../SECURITY.md) — reporting process and high-level model
+- [Pod security posture](pod-security.md)
+- [Metrics trust boundary](metrics.md)

--- a/internal/controller/conversionwebhookserver_controller.go
+++ b/internal/controller/conversionwebhookserver_controller.go
@@ -350,22 +350,18 @@ func (r *ConversionWebhookServerReconciler) reconcileDeployment(ctx context.Cont
 	args = append(args, server.Spec.ExtraArgs...)
 
 	// PSS restricted: non-root, no privilege escalation, drop all caps,
-	// read-only root FS, RuntimeDefault seccomp. Matches the distroless
-	// nonroot image USER 65532:65532. /tmp is an emptyDir because the
-	// root FS is read-only.
-	const nonRootUID int64 = 65532
+	// read-only root FS, RuntimeDefault seccomp. runAsUser/runAsGroup are
+	// intentionally unset so a custom image's non-root USER is honored;
+	// runAsNonRoot still rejects root images. /tmp is an emptyDir because
+	// the root FS is read-only.
 	containerSec := applycorev1.SecurityContext().
 		WithRunAsNonRoot(true).
-		WithRunAsUser(nonRootUID).
-		WithRunAsGroup(nonRootUID).
 		WithAllowPrivilegeEscalation(false).
 		WithReadOnlyRootFilesystem(true).
 		WithCapabilities(applycorev1.Capabilities().WithDrop(corev1.Capability("ALL"))).
 		WithSeccompProfile(applycorev1.SeccompProfile().WithType(corev1.SeccompProfileTypeRuntimeDefault))
 	podSec := applycorev1.PodSecurityContext().
 		WithRunAsNonRoot(true).
-		WithRunAsUser(nonRootUID).
-		WithRunAsGroup(nonRootUID).
 		WithSeccompProfile(applycorev1.SeccompProfile().WithType(corev1.SeccompProfileTypeRuntimeDefault))
 
 	container := applycorev1.Container().

--- a/internal/controller/conversionwebhookserver_controller.go
+++ b/internal/controller/conversionwebhookserver_controller.go
@@ -305,8 +305,13 @@ func (r *ConversionWebhookServerReconciler) reconcileDeployment(ctx context.Cont
 	}
 	var pullPolicy corev1.PullPolicy
 	if server.Spec.Image != nil {
-		if server.Spec.Image.Repository != "" && server.Spec.Image.Tag != "" {
-			image = fmt.Sprintf("%s:%s", server.Spec.Image.Repository, server.Spec.Image.Tag)
+		if server.Spec.Image.Repository != "" {
+			switch {
+			case server.Spec.Image.Digest != "":
+				image = server.Spec.Image.Repository + "@" + server.Spec.Image.Digest
+			case server.Spec.Image.Tag != "":
+				image = fmt.Sprintf("%s:%s", server.Spec.Image.Repository, server.Spec.Image.Tag)
+			}
 		}
 		pullPolicy = server.Spec.Image.PullPolicy
 	}

--- a/internal/controller/conversionwebhookserver_controller.go
+++ b/internal/controller/conversionwebhookserver_controller.go
@@ -344,15 +344,38 @@ func (r *ConversionWebhookServerReconciler) reconcileDeployment(ctx context.Cont
 	}
 	args = append(args, server.Spec.ExtraArgs...)
 
+	// PSS restricted: non-root, no privilege escalation, drop all caps,
+	// read-only root FS, RuntimeDefault seccomp. Matches the distroless
+	// nonroot image USER 65532:65532. /tmp is an emptyDir because the
+	// root FS is read-only.
+	const nonRootUID int64 = 65532
+	containerSec := applycorev1.SecurityContext().
+		WithRunAsNonRoot(true).
+		WithRunAsUser(nonRootUID).
+		WithRunAsGroup(nonRootUID).
+		WithAllowPrivilegeEscalation(false).
+		WithReadOnlyRootFilesystem(true).
+		WithCapabilities(applycorev1.Capabilities().WithDrop(corev1.Capability("ALL"))).
+		WithSeccompProfile(applycorev1.SeccompProfile().WithType(corev1.SeccompProfileTypeRuntimeDefault))
+	podSec := applycorev1.PodSecurityContext().
+		WithRunAsNonRoot(true).
+		WithRunAsUser(nonRootUID).
+		WithRunAsGroup(nonRootUID).
+		WithSeccompProfile(applycorev1.SeccompProfile().WithType(corev1.SeccompProfileTypeRuntimeDefault))
+
 	container := applycorev1.Container().
 		WithName("webhook-server").
 		WithImage(image).
 		WithArgs(args...).
+		WithSecurityContext(containerSec).
 		WithPorts(
 			applycorev1.ContainerPort().WithName("conversion").WithContainerPort(webhookServerConversionPort),
 			applycorev1.ContainerPort().WithName("metrics").WithContainerPort(webhookServerMetricsPort),
 		).
-		WithVolumeMounts(applycorev1.VolumeMount().WithName("tls").WithMountPath("/tls").WithReadOnly(true)).
+		WithVolumeMounts(
+			applycorev1.VolumeMount().WithName("tls").WithMountPath("/tls").WithReadOnly(true),
+			applycorev1.VolumeMount().WithName("tmp").WithMountPath("/tmp"),
+		).
 		WithReadinessProbe(applycorev1.Probe().
 			WithHTTPGet(applycorev1.HTTPGetAction().WithPath("/readyz").WithPort(intstr.FromInt32(webhookServerMetricsPort)).WithScheme(corev1.URISchemeHTTP)).
 			WithPeriodSeconds(5).WithFailureThreshold(3)).
@@ -368,9 +391,13 @@ func (r *ConversionWebhookServerReconciler) reconcileDeployment(ctx context.Cont
 
 	podSpec := applycorev1.PodSpec().
 		WithServiceAccountName(saName).
+		WithSecurityContext(podSec).
 		WithContainers(container).
-		WithVolumes(applycorev1.Volume().WithName("tls").
-			WithSecret(applycorev1.SecretVolumeSource().WithSecretName(cwsCertificateSecretName(server.Name))))
+		WithVolumes(
+			applycorev1.Volume().WithName("tls").
+				WithSecret(applycorev1.SecretVolumeSource().WithSecretName(cwsCertificateSecretName(server.Name))),
+			applycorev1.Volume().WithName("tmp").WithEmptyDir(applycorev1.EmptyDirVolumeSource()),
+		)
 	if len(server.Spec.NodeSelector) > 0 {
 		podSpec = podSpec.WithNodeSelector(server.Spec.NodeSelector)
 	}

--- a/internal/controller/conversionwebhookserver_controller_test.go
+++ b/internal/controller/conversionwebhookserver_controller_test.go
@@ -127,6 +127,76 @@ func TestCWSReconcile_ExtraArgs_RejectsManagedFlag(t *testing.T) {
 	}
 }
 
+func TestCWSReconcile_SecurityContext_PSSRestricted(t *testing.T) {
+	server := &teraskyv1alpha1.ConversionWebhookServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "srv"},
+		Spec: teraskyv1alpha1.ConversionWebhookServerSpec{
+			Namespace: "operator-ns",
+			Certificate: teraskyv1alpha1.CertificateSpec{
+				IssuerRef: teraskyv1alpha1.CertificateIssuerRef{Name: "ca-issuer"},
+			},
+		},
+	}
+	c := newFakeClient(server).Build()
+	r := &ConversionWebhookServerReconciler{Client: c, Scheme: newScheme(), DefaultNamespace: "operator-ns", DefaultImage: "test/image:v1"}
+
+	if _, err := reconcileCWS(t, r, "srv"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var dep appsv1.Deployment
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "srv-webhook-server", Namespace: "operator-ns"}, &dep); err != nil {
+		t.Fatalf("expected a Deployment: %v", err)
+	}
+	podSC := dep.Spec.Template.Spec.SecurityContext
+	if podSC == nil || podSC.RunAsNonRoot == nil || !*podSC.RunAsNonRoot {
+		t.Fatalf("expected pod runAsNonRoot=true, got %#v", podSC)
+	}
+	if podSC.RunAsUser == nil || *podSC.RunAsUser != 65532 {
+		t.Fatalf("expected pod runAsUser=65532, got %#v", podSC.RunAsUser)
+	}
+	if podSC.SeccompProfile == nil || podSC.SeccompProfile.Type != corev1.SeccompProfileTypeRuntimeDefault {
+		t.Fatalf("expected pod seccomp RuntimeDefault, got %#v", podSC.SeccompProfile)
+	}
+
+	if len(dep.Spec.Template.Spec.Containers) != 1 {
+		t.Fatalf("expected 1 container, got %d", len(dep.Spec.Template.Spec.Containers))
+	}
+	ctr := dep.Spec.Template.Spec.Containers[0]
+	ctrSC := ctr.SecurityContext
+	if ctrSC == nil {
+		t.Fatal("expected container securityContext")
+	}
+	if ctrSC.AllowPrivilegeEscalation == nil || *ctrSC.AllowPrivilegeEscalation {
+		t.Fatalf("expected allowPrivilegeEscalation=false")
+	}
+	if ctrSC.ReadOnlyRootFilesystem == nil || !*ctrSC.ReadOnlyRootFilesystem {
+		t.Fatalf("expected readOnlyRootFilesystem=true")
+	}
+	if ctrSC.Capabilities == nil || len(ctrSC.Capabilities.Drop) != 1 || ctrSC.Capabilities.Drop[0] != "ALL" {
+		t.Fatalf("expected capabilities.drop=[ALL], got %#v", ctrSC.Capabilities)
+	}
+
+	hasTmp := false
+	for _, m := range ctr.VolumeMounts {
+		if m.Name == "tmp" && m.MountPath == "/tmp" {
+			hasTmp = true
+		}
+	}
+	if !hasTmp {
+		t.Fatal("expected /tmp emptyDir volumeMount for read-only root FS")
+	}
+	hasTmpVol := false
+	for _, v := range dep.Spec.Template.Spec.Volumes {
+		if v.Name == "tmp" && v.EmptyDir != nil {
+			hasTmpVol = true
+		}
+	}
+	if !hasTmpVol {
+		t.Fatal("expected tmp emptyDir volume")
+	}
+}
+
 func TestCWSReconcile_HappyPath_CreatesChildResources(t *testing.T) {
 	server := &teraskyv1alpha1.ConversionWebhookServer{
 		ObjectMeta: metav1.ObjectMeta{Name: "srv"},

--- a/internal/controller/conversionwebhookserver_controller_test.go
+++ b/internal/controller/conversionwebhookserver_controller_test.go
@@ -185,8 +185,8 @@ func TestCWSReconcile_SecurityContext_PSSRestricted(t *testing.T) {
 	if podSC == nil || podSC.RunAsNonRoot == nil || !*podSC.RunAsNonRoot {
 		t.Fatalf("expected pod runAsNonRoot=true, got %#v", podSC)
 	}
-	if podSC.RunAsUser == nil || *podSC.RunAsUser != 65532 {
-		t.Fatalf("expected pod runAsUser=65532, got %#v", podSC.RunAsUser)
+	if podSC.RunAsUser != nil {
+		t.Fatalf("expected pod runAsUser unset (honor image USER), got %#v", podSC.RunAsUser)
 	}
 	if podSC.SeccompProfile == nil || podSC.SeccompProfile.Type != corev1.SeccompProfileTypeRuntimeDefault {
 		t.Fatalf("expected pod seccomp RuntimeDefault, got %#v", podSC.SeccompProfile)
@@ -199,6 +199,12 @@ func TestCWSReconcile_SecurityContext_PSSRestricted(t *testing.T) {
 	ctrSC := ctr.SecurityContext
 	if ctrSC == nil {
 		t.Fatal("expected container securityContext")
+	}
+	if ctrSC.RunAsNonRoot == nil || !*ctrSC.RunAsNonRoot {
+		t.Fatalf("expected container runAsNonRoot=true, got %#v", ctrSC.RunAsNonRoot)
+	}
+	if ctrSC.RunAsUser != nil {
+		t.Fatalf("expected container runAsUser unset (honor image USER), got %#v", ctrSC.RunAsUser)
 	}
 	if ctrSC.AllowPrivilegeEscalation == nil || *ctrSC.AllowPrivilegeEscalation {
 		t.Fatalf("expected allowPrivilegeEscalation=false")

--- a/internal/controller/conversionwebhookserver_controller_test.go
+++ b/internal/controller/conversionwebhookserver_controller_test.go
@@ -127,6 +127,39 @@ func TestCWSReconcile_ExtraArgs_RejectsManagedFlag(t *testing.T) {
 	}
 }
 
+func TestCWSReconcile_ImageDigest_PinsRepository(t *testing.T) {
+	server := &teraskyv1alpha1.ConversionWebhookServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "srv"},
+		Spec: teraskyv1alpha1.ConversionWebhookServerSpec{
+			Namespace: "operator-ns",
+			Certificate: teraskyv1alpha1.CertificateSpec{
+				IssuerRef: teraskyv1alpha1.CertificateIssuerRef{Name: "ca-issuer"},
+			},
+			Image: &teraskyv1alpha1.ImageSpec{
+				Repository: "ghcr.io/example/webhook-server",
+				Tag:        "v9.9.9", // digest must win over tag
+				Digest:     "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			},
+		},
+	}
+	c := newFakeClient(server).Build()
+	r := &ConversionWebhookServerReconciler{Client: c, Scheme: newScheme(), DefaultNamespace: "operator-ns", DefaultImage: "test/image:v1"}
+
+	if _, err := reconcileCWS(t, r, "srv"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var dep appsv1.Deployment
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "srv-webhook-server", Namespace: "operator-ns"}, &dep); err != nil {
+		t.Fatalf("expected a Deployment: %v", err)
+	}
+	got := dep.Spec.Template.Spec.Containers[0].Image
+	want := "ghcr.io/example/webhook-server@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	if got != want {
+		t.Fatalf("image=%q, want %q", got, want)
+	}
+}
+
 func TestCWSReconcile_SecurityContext_PSSRestricted(t *testing.T) {
 	server := &teraskyv1alpha1.ConversionWebhookServer{
 		ObjectMeta: metav1.ObjectMeta{Name: "srv"},

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -100,6 +100,7 @@ nav:
   - Security:
       - security/pod-security.md
       - security/metrics.md
+      - security/rbac.md
   - Roadmap: roadmap.md
 
 extra:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -97,6 +97,8 @@ nav:
       - List Join / Split: strategies/list-join-split.md
   - FAQ: faq.md
   - Limitations: limitations.md
+  - Security:
+      - security/pod-security.md
   - Roadmap: roadmap.md
 
 extra:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -98,9 +98,9 @@ nav:
   - FAQ: faq.md
   - Limitations: limitations.md
   - Security:
-      - security/pod-security.md
-      - security/metrics.md
-      - security/rbac.md
+      - Pod security: security/pod-security.md
+      - Metrics trust boundary: security/metrics.md
+      - RBAC blast radius: security/rbac.md
   - Roadmap: roadmap.md
 
 extra:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -99,6 +99,7 @@ nav:
   - Limitations: limitations.md
   - Security:
       - security/pod-security.md
+      - security/metrics.md
   - Roadmap: roadmap.md
 
 extra:


### PR DESCRIPTION
## Summary
Single PR for [Epic #14](https://github.com/TeraSky-OSS/declarative-conversion-operator/issues/14) — one commit per sub-issue:

1. **1.1** — PSS `restricted` `securityContext` on CWS-managed webhook-server pods (+ `/tmp` emptyDir)
2. **1.2** — Align manager Deployment PSS with CWS; document side-by-side in `docs/security/pod-security.md`
3. **1.3** — Opt-in NetworkPolicy templates (`networkPolicy.enabled`, default off)
4. **1.4** — Document metrics trust boundary / NetworkPolicy lock-down
5. **1.5** — Add `SECURITY.md`
6. **1.6** — Optional image digest pinning (Helm + `ConversionWebhookServer.spec.image.digest`)
7. **1.7** — RBAC blast-radius docs

Closes #15
Closes #16
Closes #17
Closes #18
Closes #19
Closes #20
Closes #21
Closes #14

## Test plan
- [x] `make test`
- [x] `make test-e2e`
- [x] `helm template --set networkPolicy.enabled=true` renders NetworkPolicies; default renders none
- [x] `helm template --set image.manager.digest=sha256:...` renders `@sha256:...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added digest-based image pinning for manager and webhook server images.
  * Added opt-in Kubernetes NetworkPolicy configuration, including metrics peer restrictions.
  * Strengthened workload security with non-root execution, read-only filesystems, seccomp, and restricted capabilities.
* **Documentation**
  * Added security guidance covering vulnerability reporting, pod security, metrics, and RBAC.
  * Documented image digest and NetworkPolicy configuration.
* **Tests**
  * Added coverage for digest selection and security settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->