### PR TITLE
Phase 2: Resilience and operator correctness

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -61,7 +61,7 @@ Each `ConversionWebhookServer` replica is symmetric and self-sufficient — ther
 | `ConversionWebhookServer` deleted/scaled to 0 while configs still reference it (including as `default`) | Finalizer blocks deletion unless zero configs resolve to it, or the explicit force-delete annotation is present. |
 | A config update makes a previously-lossless conversion lossy | Full re-validation happens before any XRD patch; a regression sets `Invalid` and the old plan keeps running unpatched. |
 | The XRD's schema drifts after a config was `Applied` | Re-validated every reconcile. A clean drift self-heals silently; a failing one goes loudly `Stale` but keeps serving the last known-good plan by default (`driftPolicy: KeepServingStale`). |
-| Two configs target the same XRD | Blocked structurally by a unique field index plus the admission webhook — never a race to resolve at runtime. |
+| Two configs target the same XRD/CRD name | Blocked by admission webhook uniqueness across both XRDConversionConfig and CRDConversionConfig — registry keys are the bare target name, so cross-kind collisions are rejected too. |
 | The cert-manager `Certificate` rotates | The controller watches the Secret directly and refreshes `caBundle` on the XRD — cert-manager's CA injector doesn't support `CompositeResourceDefinition` as an injection target. |
 
 ## Repository layout

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -58,7 +58,7 @@ Each `ConversionWebhookServer` replica is symmetric and self-sufficient — ther
 | Scenario | Mitigation |
 |---|---|
 | Config deleted while the XRD still has >1 served version | Finalizer blocks deletion unless ≤1 served version remains, or the explicit unsafe-delete annotation is present. See [Config delete race window](#config-delete-race-window) for the precise ordering and residual windows. |
-| `ConversionWebhookServer` deleted/scaled to 0 while configs still reference it (including as `default`) | Finalizer blocks deletion unless zero configs resolve to it, or the explicit force-delete annotation is present. |
+| `ConversionWebhookServer` deleted while configs still reference it (including as `default`) | Finalizer blocks **deletion** unless zero configs resolve to it, or the explicit force-delete annotation is present. Scaling replicas to zero is not blocked by the finalizer — readiness/availability gates on configs surface that separately. |
 | A config update makes a previously-lossless conversion lossy | Full re-validation happens before any XRD patch; a regression sets `Invalid` and the old plan keeps running unpatched. |
 | The XRD's schema drifts after a config was `Applied` | Re-validated every reconcile. A clean drift self-heals silently; a failing one goes loudly `Stale` but keeps serving the last known-good plan by default (`driftPolicy: KeepServingStale`). |
 | Two configs target the same XRD/CRD name | Blocked by admission webhook uniqueness across both XRDConversionConfig and CRDConversionConfig — registry keys are the bare target name, so cross-kind collisions are rejected too. |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -57,13 +57,54 @@ Each `ConversionWebhookServer` replica is symmetric and self-sufficient — ther
 
 | Scenario | Mitigation |
 |---|---|
-| Config deleted while the XRD still has >1 served version | Finalizer blocks deletion unless ≤1 served version remains, or the explicit unsafe-delete annotation is present. |
+| Config deleted while the XRD still has >1 served version | Finalizer blocks deletion unless ≤1 served version remains, or the explicit unsafe-delete annotation is present. See [Config delete race window](#config-delete-race-window) for the precise ordering and residual windows. |
 | `ConversionWebhookServer` deleted/scaled to 0 while configs still reference it (including as `default`) | Finalizer blocks deletion unless zero configs resolve to it, or the explicit force-delete annotation is present. |
 | A config update makes a previously-lossless conversion lossy | Full re-validation happens before any XRD patch; a regression sets `Invalid` and the old plan keeps running unpatched. |
 | The XRD's schema drifts after a config was `Applied` | Re-validated every reconcile. A clean drift self-heals silently; a failing one goes loudly `Stale` but keeps serving the last known-good plan by default (`driftPolicy: KeepServingStale`). |
 | Two configs target the same XRD/CRD name | Blocked by admission webhook uniqueness across both XRDConversionConfig and CRDConversionConfig — registry keys are the bare target name, so cross-kind collisions are rejected too. |
 | `ConversionWebhookServer` change enqueues many configs | Only configs currently assigned to that server are enqueued, paced at 50 QPS (`internal/enqueue.CWSConfigEnqueueQPS`) so a 200-config fan-out spreads over ~4s instead of an unbounded workqueue burst. |
 | The cert-manager `Certificate` rotates | The controller watches the Secret directly and refreshes `caBundle` on the XRD — cert-manager's CA injector doesn't support `CompositeResourceDefinition` as an injection target. |
+
+## Config delete race window
+
+Both `XRDConversionConfig` and `CRDConversionConfig` use a finalizer
+(`conversion.terasky.com/safe-revert` / `.../safe-revert-crd`) so deletion
+is not instantaneous. The delete reconcile does the following, in order:
+
+1. **No finalizer** → nothing to do (object already releasing).
+2. **Phase is neither `Applied` nor `Stale`** → remove the finalizer
+   immediately (never applied, or already torn down). **No target revert.**
+3. **Target XRD/CRD is gone** → remove the finalizer (nothing to revert).
+4. **Target still serves >1 version** and the live object does **not** carry
+   `conversion.terasky.com/allow-unsafe-delete=true` → set
+   `DeletionBlocked`, keep the finalizer, requeue in 30s.
+5. **Otherwise** → **revert first** (`spec.conversion.strategy=None` via
+   SSA), **then** remove the finalizer.
+
+So the common “finalizer removed while the target still has webhook
+conversion” race the roadmap flagged is **not** the successful-path
+ordering: revert completes before the finalizer drops. The residual
+windows are narrower:
+
+| Window | What can happen | Mitigation / why accepted |
+|---|---|---|
+| Crash after target SSA patch but **before** status reaches `Phase=Applied` | A subsequent delete sees a non-Applied/non-Stale phase and removes the finalizer **without** reverting, leaving webhook conversion on the target | Narrow crash window; restart without delete re-applies idempotently and persists `Applied` (covered by Phase 2.1 failure tests). Operators deleting in that exact window should clear conversion manually or re-create a config. |
+| Crash after successful revert but before finalizer removal | Finalizer remains; next delete reconcile reverts again (idempotent) then removes the finalizer | Self-heals on retry. |
+| After finalizer removal, webhook-server replicas still hold a compiled plan until their watch fires | In-memory plan may exist briefly while the apiserver already has `strategy: None` | Harmless: the apiserver will not call the conversion webhook once strategy is `None`. |
+| Break-glass annotation | Checked **live** on the delete reconcile only — must be present on the object being deleted right now | Documented on the config pages; not a sticky historical flag. |
+
+### Evaluation: is an admission-time DELETE guard warranted?
+
+An admission webhook that refused DELETE while the live target still had
+this operator’s webhook conversion would close the apply-before-status
+crash window above. It would not replace the multi-served-version
+finalizer (admission cannot hold an object open across a long-running
+revert the way a finalizer can).
+
+**Conclusion:** the current finalizer model is sufficient. The residual
+window is crash-only and already has restart recovery coverage; adding
+DELETE admission would add complexity for little operational gain. No
+follow-up hardening issue is filed from this writeup.
 
 ## Repository layout
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -62,6 +62,7 @@ Each `ConversionWebhookServer` replica is symmetric and self-sufficient — ther
 | A config update makes a previously-lossless conversion lossy | Full re-validation happens before any XRD patch; a regression sets `Invalid` and the old plan keeps running unpatched. |
 | The XRD's schema drifts after a config was `Applied` | Re-validated every reconcile. A clean drift self-heals silently; a failing one goes loudly `Stale` but keeps serving the last known-good plan by default (`driftPolicy: KeepServingStale`). |
 | Two configs target the same XRD/CRD name | Blocked by admission webhook uniqueness across both XRDConversionConfig and CRDConversionConfig — registry keys are the bare target name, so cross-kind collisions are rejected too. |
+| `ConversionWebhookServer` change enqueues many configs | Only configs currently assigned to that server are enqueued, paced at 50 QPS (`internal/enqueue.CWSConfigEnqueueQPS`) so a 200-config fan-out spreads over ~4s instead of an unbounded workqueue burst. |
 | The cert-manager `Certificate` rotates | The controller watches the Secret directly and refreshes `caBundle` on the XRD — cert-manager's CA injector doesn't support `CompositeResourceDefinition` as an injection target. |
 
 ## Repository layout

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -51,3 +51,11 @@ access.
 
 - Metrics trust boundary and NetworkPolicy: [security/metrics.md](security/metrics.md)
 - ConversionWebhookServer status fields: [configuration/conversionwebhookserver.md](configuration/conversionwebhookserver.md)
+
+## Controller watch-mapping errors
+
+When a secondary watch map function fails to `List` related configs (API
+timeout, etc.), the failure is logged and counted as
+`xrdconv_watch_map_list_errors_total{map_func=...}` instead of looking like
+a legitimate empty result. Configs still periodically self-reconcile
+(`RequeueAfter`), so a transient List miss recovers without pod restart.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,53 @@
+# Observability
+
+How to tell whether conversion configs are actually loaded and serving —
+without `kubectl exec` into a webhook-server pod.
+
+## Registry readiness (per replica)
+
+Each ConversionWebhookServer replica owns an in-memory registry of
+compiled plans. Desired assignment on the CWS object
+(`status.assignedConfigs`) is **not** proof that a given replica has
+loaded those configs — that state is local to each pod.
+
+Scraped Prometheus metrics on the webhook-server metrics port (`8443`,
+path `/metrics`) are the supported signal:
+
+| Metric | Meaning |
+|---|---|
+| `xrdconv_webhook_ready` | `1` after initial sync completed on this replica |
+| `xrdconv_webhook_registry_size` | Count of registry entries on this replica (includes error-only placeholders) |
+| `xrdconv_webhook_registry_entry_loaded{xrd="<target>"}` | `1` if this replica has a compiled, servable plan for that XRD/CRD target name; `0` if the entry exists but is error-only |
+| `xrdconv_webhook_registry_last_reload_timestamp_seconds{xrd=...}` | Last successful compile time |
+| `xrdconv_webhook_registry_compile_errors_total{xrd=...,reason=...}` | Compile failures that left stale-or-absent plans in place |
+
+Replica identity comes from the Prometheus scrape target (pod label /
+instance). Example: confirm target `xfoos.example.org` is loaded on every
+ready webhook-server pod:
+
+```promql
+xrdconv_webhook_registry_entry_loaded{xrd="xfoos.example.org"} == 1
+```
+
+Compare desired assignment count on the CWS status with live load:
+
+```promql
+# per-replica loaded (servable) entries
+count by (pod) (xrdconv_webhook_registry_entry_loaded == 1)
+```
+
+`ConversionWebhookServer.status.assignedConfigs` remains the cluster-level
+**desired** set computed by the shared resolver. Use it together with the
+per-pod gauges above — not as a substitute for them.
+
+## Debug endpoint (break-glass)
+
+`GET /debug/registry` on the plain-HTTP port still returns a JSON snapshot
+of the local registry. Prefer metrics for alerting and routine checks;
+use the debug endpoint only when you already have pod exec / port-forward
+access.
+
+## Related
+
+- Metrics trust boundary and NetworkPolicy: [security/metrics.md](security/metrics.md)
+- ConversionWebhookServer status fields: [configuration/conversionwebhookserver.md](configuration/conversionwebhookserver.md)

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -21,13 +21,18 @@ path `/metrics`) are the supported signal:
 | `xrdconv_webhook_registry_last_reload_timestamp_seconds{xrd=...}` | Last successful compile time |
 | `xrdconv_webhook_registry_compile_errors_total{xrd=...,reason=...}` | Compile failures that left stale-or-absent plans in place |
 
-Replica identity comes from the Prometheus scrape target (pod label /
-instance). Example: confirm target `xfoos.example.org` is loaded on every
-ready webhook-server pod:
+Replica identity comes from the Prometheus scrape target (pod / instance
+label). Example: confirm every **ready** webhook-server pod has loaded
+target `xfoos.example.org` (empty result = healthy):
 
 ```promql
-xrdconv_webhook_registry_entry_loaded{xrd="xfoos.example.org"} == 1
+(xrdconv_webhook_ready == 1)
+  unless on (pod)
+(xrdconv_webhook_registry_entry_loaded{xrd="xfoos.example.org"} == 1)
 ```
+
+Use `instance` instead of `pod` if that is the stable scrape identity in
+your Prometheus config.
 
 Compare desired assignment count on the CWS status with live load:
 

--- a/internal/controller/conversionwebhookserver_controller.go
+++ b/internal/controller/conversionwebhookserver_controller.go
@@ -47,6 +47,7 @@ import (
 
 	teraskyv1alpha1 "github.com/terasky-oss/declarative-conversion-operator/api/v1alpha1"
 	"github.com/terasky-oss/declarative-conversion-operator/internal/assign"
+	"github.com/terasky-oss/declarative-conversion-operator/internal/watchmap"
 )
 
 // CertificateGroupVersionKind identifies a cert-manager Certificate.
@@ -665,7 +666,7 @@ func enqueueAllServers(c client.Client) func(ctx context.Context, obj client.Obj
 	return func(ctx context.Context, _ client.Object) []reconcile.Request {
 		var list teraskyv1alpha1.ConversionWebhookServerList
 		if err := c.List(ctx, &list); err != nil {
-			return nil
+			return watchmap.ListError(ctx, "conversionwebhookserver.enqueueAllServers", err)
 		}
 		reqs := make([]reconcile.Request, 0, len(list.Items))
 		for _, s := range list.Items {

--- a/internal/controller/crdconversionconfig_controller.go
+++ b/internal/controller/crdconversionconfig_controller.go
@@ -41,6 +41,7 @@ import (
 	teraskyv1alpha1 "github.com/terasky-oss/declarative-conversion-operator/api/v1alpha1"
 	"github.com/terasky-oss/declarative-conversion-operator/internal/assign"
 	"github.com/terasky-oss/declarative-conversion-operator/internal/enqueue"
+	"github.com/terasky-oss/declarative-conversion-operator/internal/watchmap"
 	"github.com/terasky-oss/declarative-conversion-operator/pkg/crdadapter"
 	"github.com/terasky-oss/declarative-conversion-operator/pkg/engine"
 )
@@ -457,7 +458,7 @@ func (r *CRDConversionConfigReconciler) SetupWithManager(mgr ctrl.Manager) error
 func (r *CRDConversionConfigReconciler) mapCRDToConfigs(ctx context.Context, obj client.Object) []reconcile.Request {
 	var list teraskyv1alpha1.CRDConversionConfigList
 	if err := r.List(ctx, &list, client.MatchingFields{TargetCRDNameIndex: obj.GetName()}); err != nil {
-		return nil
+		return watchmap.ListError(ctx, "crdconversionconfig.mapCRDToConfigs", err)
 	}
 	reqs := make([]reconcile.Request, 0, len(list.Items))
 	for _, c := range list.Items {
@@ -469,7 +470,7 @@ func (r *CRDConversionConfigReconciler) mapCRDToConfigs(ctx context.Context, obj
 func (r *CRDConversionConfigReconciler) mapServerToAssignedConfigs(ctx context.Context, obj client.Object) []reconcile.Request {
 	reqs, err := mapServerToAssignedCRDConfigs(ctx, r.Client, obj)
 	if err != nil {
-		return nil
+		return watchmap.ListError(ctx, "crdconversionconfig.mapServerToAssignedConfigs", err)
 	}
 	return reqs
 }

--- a/internal/controller/crdconversionconfig_controller.go
+++ b/internal/controller/crdconversionconfig_controller.go
@@ -450,7 +450,7 @@ func (r *CRDConversionConfigReconciler) SetupWithManager(mgr ctrl.Manager) error
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&teraskyv1alpha1.CRDConversionConfig{}).
 		Watches(&extv1.CustomResourceDefinition{}, handler.EnqueueRequestsFromMapFunc(r.mapCRDToConfigs)).
-		Watches(&teraskyv1alpha1.ConversionWebhookServer{}, enqueue.PacedMapFunc(r.mapServerToAssignedConfigs, enqueue.CWSConfigEnqueueQPS)).
+		Watches(&teraskyv1alpha1.ConversionWebhookServer{}, enqueue.PacedMapFuncs(r.mapServerToAssignedConfigs, r.mapServerTransitionToAssignedConfigs, enqueue.CWSConfigEnqueueQPS)).
 		Named("crdconversionconfig").
 		Complete(r)
 }
@@ -471,6 +471,14 @@ func (r *CRDConversionConfigReconciler) mapServerToAssignedConfigs(ctx context.C
 	reqs, err := mapServerToAssignedCRDConfigs(ctx, r.Client, obj)
 	if err != nil {
 		return watchmap.ListError(ctx, "crdconversionconfig.mapServerToAssignedConfigs", err)
+	}
+	return reqs
+}
+
+func (r *CRDConversionConfigReconciler) mapServerTransitionToAssignedConfigs(ctx context.Context, oldObj, newObj client.Object) []reconcile.Request {
+	reqs, err := mapServerTransitionToAssignedCRDConfigs(ctx, r.Client, oldObj, newObj)
+	if err != nil {
+		return watchmap.ListError(ctx, "crdconversionconfig.mapServerTransitionToAssignedConfigs", err)
 	}
 	return reqs
 }

--- a/internal/controller/crdconversionconfig_controller.go
+++ b/internal/controller/crdconversionconfig_controller.go
@@ -40,6 +40,7 @@ import (
 
 	teraskyv1alpha1 "github.com/terasky-oss/declarative-conversion-operator/api/v1alpha1"
 	"github.com/terasky-oss/declarative-conversion-operator/internal/assign"
+	"github.com/terasky-oss/declarative-conversion-operator/internal/enqueue"
 	"github.com/terasky-oss/declarative-conversion-operator/pkg/crdadapter"
 	"github.com/terasky-oss/declarative-conversion-operator/pkg/engine"
 )
@@ -448,7 +449,7 @@ func (r *CRDConversionConfigReconciler) SetupWithManager(mgr ctrl.Manager) error
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&teraskyv1alpha1.CRDConversionConfig{}).
 		Watches(&extv1.CustomResourceDefinition{}, handler.EnqueueRequestsFromMapFunc(r.mapCRDToConfigs)).
-		Watches(&teraskyv1alpha1.ConversionWebhookServer{}, handler.EnqueueRequestsFromMapFunc(r.mapAnyServerToAllConfigs)).
+		Watches(&teraskyv1alpha1.ConversionWebhookServer{}, enqueue.PacedMapFunc(r.mapServerToAssignedConfigs, enqueue.CWSConfigEnqueueQPS)).
 		Named("crdconversionconfig").
 		Complete(r)
 }
@@ -465,14 +466,10 @@ func (r *CRDConversionConfigReconciler) mapCRDToConfigs(ctx context.Context, obj
 	return reqs
 }
 
-func (r *CRDConversionConfigReconciler) mapAnyServerToAllConfigs(ctx context.Context, _ client.Object) []reconcile.Request {
-	var list teraskyv1alpha1.CRDConversionConfigList
-	if err := r.List(ctx, &list); err != nil {
+func (r *CRDConversionConfigReconciler) mapServerToAssignedConfigs(ctx context.Context, obj client.Object) []reconcile.Request {
+	reqs, err := mapServerToAssignedCRDConfigs(ctx, r.Client, obj)
+	if err != nil {
 		return nil
-	}
-	reqs := make([]reconcile.Request, 0, len(list.Items))
-	for _, c := range list.Items {
-		reqs = append(reqs, reconcile.Request{NamespacedName: types.NamespacedName{Name: c.Name}})
 	}
 	return reqs
 }

--- a/internal/controller/crdconversionconfig_controller_failure_test.go
+++ b/internal/controller/crdconversionconfig_controller_failure_test.go
@@ -1,0 +1,310 @@
+/*
+Copyright 2026 The declarative-conversion-operator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	teraskyv1alpha1 "github.com/terasky-oss/declarative-conversion-operator/api/v1alpha1"
+)
+
+// Phase 2.1 failure-path coverage for CRDConversionConfig — mirrors the
+// XRD scenarios in xrdconversionconfig_controller_failure_test.go.
+
+func TestCRDReconcile_CrashBeforePatch_RestartsAndApplies(t *testing.T) {
+	crd := establishedCRD("foos.example.org")
+	cfg := renameRuleCRDConfig("cfg", "foos.example.org")
+	server, secret := readyServer("srv")
+
+	var applyCalls atomic.Int32
+	c := newFakeClient(crd, cfg, server, secret).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Apply: func(ctx context.Context, c client.WithWatch, obj runtime.ApplyConfiguration, opts ...client.ApplyOption) error {
+				if applyCalls.Add(1) == 1 {
+					return fmt.Errorf("injected crash before CRD patch")
+				}
+				return c.Apply(ctx, obj, opts...)
+			},
+		}).
+		Build()
+	r := &CRDConversionConfigReconciler{Client: c, DefaultServerNamespace: "operator-ns"}
+
+	_, err := reconcileCRD(t, r, "cfg")
+	if err == nil {
+		t.Fatalf("expected reconcile error when CRD patch crashes")
+	}
+	got := getCRDConfig(t, r, "cfg")
+	if got.Status.Phase == teraskyv1alpha1.PhaseApplied {
+		t.Fatalf("must not report Applied after a failed patch; phase=%q", got.Status.Phase)
+	}
+	var live extv1.CustomResourceDefinition
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "foos.example.org"}, &live); err != nil {
+		t.Fatalf("getting CRD: %v", err)
+	}
+	if live.Spec.Conversion != nil && live.Spec.Conversion.Strategy == extv1.WebhookConverter {
+		t.Fatalf("CRD must remain unpatched after crash-before-patch")
+	}
+
+	if _, err := reconcileCRD(t, r, "cfg"); err != nil {
+		t.Fatalf("restart reconcile: %v", err)
+	}
+	got = getCRDConfig(t, r, "cfg")
+	if got.Status.Phase != teraskyv1alpha1.PhaseApplied {
+		t.Fatalf("expected Applied after restart, got %q (%s)", got.Status.Phase, got.Status.Message)
+	}
+}
+
+func TestCRDReconcile_CrashAfterPatchBeforeStatus_RestartsIdempotently(t *testing.T) {
+	crd := establishedCRD("foos.example.org")
+	cfg := renameRuleCRDConfig("cfg", "foos.example.org")
+	server, secret := readyServer("srv")
+
+	var statusPatches atomic.Int32
+	c := newFakeClient(crd, cfg, server, secret).
+		WithInterceptorFuncs(interceptor.Funcs{
+			SubResourcePatch: func(ctx context.Context, c client.Client, subResourceName string, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+				if subResourceName == "status" {
+					if statusPatches.Add(1) == 1 {
+						return fmt.Errorf("injected crash before status Applied")
+					}
+				}
+				return c.SubResource(subResourceName).Patch(ctx, obj, patch, opts...)
+			},
+		}).
+		Build()
+	r := &CRDConversionConfigReconciler{Client: c, DefaultServerNamespace: "operator-ns"}
+
+	_, err := reconcileCRD(t, r, "cfg")
+	if err == nil {
+		t.Fatalf("expected error when status patch crashes after CRD apply")
+	}
+	got := getCRDConfig(t, r, "cfg")
+	if got.Status.Phase == teraskyv1alpha1.PhaseApplied {
+		t.Fatalf("status must not show Applied after crashed status write; phase=%q", got.Status.Phase)
+	}
+	var live extv1.CustomResourceDefinition
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "foos.example.org"}, &live); err != nil {
+		t.Fatalf("getting CRD: %v", err)
+	}
+	if live.Spec.Conversion == nil || live.Spec.Conversion.Strategy != extv1.WebhookConverter {
+		t.Fatalf("expected CRD already patched to Webhook before the status crash, got %+v", live.Spec.Conversion)
+	}
+	// The fake client's typed SSA Apply can strip Spec.Versions on a
+	// conversion-only patch. Re-seed them so the restart path exercises
+	// idempotent status persistence rather than a schema-loss artifact.
+	if len(live.Spec.Versions) == 0 {
+		fresh := establishedCRD("foos.example.org")
+		live.Spec.Versions = fresh.Spec.Versions
+		live.Spec.Group = fresh.Spec.Group
+		live.Spec.Names = fresh.Spec.Names
+		live.Spec.Scope = fresh.Spec.Scope
+		if err := r.Update(context.Background(), &live); err != nil {
+			t.Fatalf("restoring CRD versions after fake-client Apply: %v", err)
+		}
+	}
+
+	if _, err := reconcileCRD(t, r, "cfg"); err != nil {
+		t.Fatalf("restart reconcile: %v", err)
+	}
+	got = getCRDConfig(t, r, "cfg")
+	if got.Status.Phase != teraskyv1alpha1.PhaseApplied {
+		t.Fatalf("expected Applied after restart, got %q (%s)", got.Status.Phase, got.Status.Message)
+	}
+}
+
+func TestCRDReconcile_SchemaDriftMidLifecycle_KeepServingStale(t *testing.T) {
+	// Seed a previously-applied config with live webhook conversion. The
+	// fake client's typed SSA Apply for CRDs can strip Spec.Versions, so
+	// we avoid depending on a full apply round-trip here and focus on the
+	// drift-policy branch under a mid-lifecycle schema change.
+	crd := establishedCRD("foos.example.org")
+	crd.Spec.Conversion = &extv1.CustomResourceConversion{
+		Strategy: extv1.WebhookConverter,
+		Webhook: &extv1.WebhookConversion{
+			ClientConfig: &extv1.WebhookClientConfig{URL: strPtr("https://example.invalid/convert")},
+		},
+	}
+	cfg := renameRuleCRDConfig("cfg", "foos.example.org")
+	cfg.Spec.DriftPolicy = teraskyv1alpha1.DriftPolicyKeepServingStale
+	cfg.Status.Phase = teraskyv1alpha1.PhaseApplied
+	controllerutil.AddFinalizer(cfg, teraskyv1alpha1.CRDConversionConfigFinalizer)
+	server, secret := readyServer("srv")
+
+	c := newFakeClient(crd, cfg, server, secret).Build()
+	r := &CRDConversionConfigReconciler{Client: c, DefaultServerNamespace: "operator-ns"}
+
+	var live extv1.CustomResourceDefinition
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "foos.example.org"}, &live); err != nil {
+		t.Fatalf("getting CRD: %v", err)
+	}
+	live.Spec.Versions[0].Schema = &extv1.CustomResourceValidation{OpenAPIV3Schema: &extv1.JSONSchemaProps{
+		Type: "object",
+		Properties: map[string]extv1.JSONSchemaProps{
+			"spec": {Type: "object", Properties: map[string]extv1.JSONSchemaProps{
+				"capacity": {Type: "string"},
+			}},
+		},
+	}}
+	live.Generation = 2
+	if err := r.Update(context.Background(), &live); err != nil {
+		t.Fatalf("updating drifted CRD: %v", err)
+	}
+
+	if _, err := reconcileCRD(t, r, "cfg"); err != nil {
+		t.Fatalf("drift reconcile: %v", err)
+	}
+	got := getCRDConfig(t, r, "cfg")
+	if got.Status.Phase != teraskyv1alpha1.PhaseStale {
+		t.Fatalf("expected Stale under KeepServingStale schema drift, got %q (%s)", got.Status.Phase, got.Status.Message)
+	}
+	if !meta.IsStatusConditionTrue(got.Status.Conditions, teraskyv1alpha1.ConditionStale) {
+		t.Fatalf("expected ConditionStale=True, got %+v", got.Status.Conditions)
+	}
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "foos.example.org"}, &live); err != nil {
+		t.Fatalf("getting CRD after drift: %v", err)
+	}
+	if live.Spec.Conversion == nil || live.Spec.Conversion.Strategy != extv1.WebhookConverter {
+		t.Fatalf("KeepServingStale must leave webhook conversion in place, got %+v", live.Spec.Conversion)
+	}
+}
+
+func TestCRDReconcile_SchemaDriftMidLifecycle_FailClosedReverts(t *testing.T) {
+	crd := establishedCRD("foos.example.org")
+	crd.Spec.Conversion = &extv1.CustomResourceConversion{
+		Strategy: extv1.WebhookConverter,
+		Webhook: &extv1.WebhookConversion{
+			ClientConfig: &extv1.WebhookClientConfig{URL: strPtr("https://example.invalid/convert")},
+		},
+	}
+	cfg := renameRuleCRDConfig("cfg", "foos.example.org")
+	cfg.Spec.DriftPolicy = teraskyv1alpha1.DriftPolicyFailClosed
+	cfg.Status.Phase = teraskyv1alpha1.PhaseApplied
+	controllerutil.AddFinalizer(cfg, teraskyv1alpha1.CRDConversionConfigFinalizer)
+	server, secret := readyServer("srv")
+
+	c := newFakeClient(crd, cfg, server, secret).Build()
+	r := &CRDConversionConfigReconciler{Client: c, DefaultServerNamespace: "operator-ns"}
+
+	var live extv1.CustomResourceDefinition
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "foos.example.org"}, &live); err != nil {
+		t.Fatalf("getting CRD: %v", err)
+	}
+	live.Spec.Versions[0].Schema = &extv1.CustomResourceValidation{OpenAPIV3Schema: &extv1.JSONSchemaProps{
+		Type: "object",
+		Properties: map[string]extv1.JSONSchemaProps{
+			"spec": {Type: "object", Properties: map[string]extv1.JSONSchemaProps{
+				"capacity": {Type: "string"},
+			}},
+		},
+	}}
+	live.Generation = 2
+	if err := r.Update(context.Background(), &live); err != nil {
+		t.Fatalf("updating drifted CRD: %v", err)
+	}
+
+	if _, err := reconcileCRD(t, r, "cfg"); err != nil {
+		t.Fatalf("drift reconcile: %v", err)
+	}
+	got := getCRDConfig(t, r, "cfg")
+	if got.Status.Phase != teraskyv1alpha1.PhaseFailed {
+		t.Fatalf("expected Failed under FailClosed schema drift, got %q (%s)", got.Status.Phase, got.Status.Message)
+	}
+	applied := meta.FindStatusCondition(got.Status.Conditions, teraskyv1alpha1.ConditionApplied)
+	if applied == nil || applied.Reason != teraskyv1alpha1.ReasonReverted {
+		t.Fatalf("expected Reason=Reverted, got %+v", applied)
+	}
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "foos.example.org"}, &live); err != nil {
+		t.Fatalf("getting CRD after FailClosed: %v", err)
+	}
+	if live.Spec.Conversion == nil || live.Spec.Conversion.Strategy != extv1.NoneConverter {
+		t.Fatalf("FailClosed must revert to strategy=None, got %+v", live.Spec.Conversion)
+	}
+}
+
+func TestCRDReconcile_FailClosed_PartwayRevertThenRecover(t *testing.T) {
+	crd := establishedCRD("foos.example.org")
+	crd.Spec.Conversion = &extv1.CustomResourceConversion{
+		Strategy: extv1.WebhookConverter,
+		Webhook: &extv1.WebhookConversion{
+			ClientConfig: &extv1.WebhookClientConfig{URL: strPtr("https://example.invalid/convert")},
+		},
+	}
+	cfg := renameRuleCRDConfig("cfg", "foos.example.org")
+	cfg.Spec.DriftPolicy = teraskyv1alpha1.DriftPolicyFailClosed
+	cfg.Status.Phase = teraskyv1alpha1.PhaseApplied
+	meta.SetStatusCondition(&cfg.Status.Conditions, metav1.Condition{
+		Type: teraskyv1alpha1.ConditionApplied, Status: metav1.ConditionTrue, Reason: "Applied", Message: "previously applied",
+	})
+	controllerutil.AddFinalizer(cfg, teraskyv1alpha1.CRDConversionConfigFinalizer)
+	server, secret := readyServer("srv")
+
+	var applyCalls atomic.Int32
+	c := newFakeClient(crd, cfg, server, secret).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Apply: func(ctx context.Context, c client.WithWatch, obj runtime.ApplyConfiguration, opts ...client.ApplyOption) error {
+				if applyCalls.Add(1) == 1 {
+					return fmt.Errorf("injected partway revert failure")
+				}
+				return c.Apply(ctx, obj, opts...)
+			},
+		}).
+		Build()
+	r := &CRDConversionConfigReconciler{Client: c, DefaultServerNamespace: "operator-ns"}
+
+	live := getCRDConfig(t, r, "cfg")
+	live.Spec.Spokes[0].Rules[0].FieldRename.HubPath = "spec.doesNotExist"
+	if err := r.Update(context.Background(), live); err != nil {
+		t.Fatalf("updating config: %v", err)
+	}
+
+	if _, err := reconcileCRD(t, r, "cfg"); err == nil {
+		t.Fatalf("expected partway revert to return an error")
+	}
+	got := getCRDConfig(t, r, "cfg")
+	applied := meta.FindStatusCondition(got.Status.Conditions, teraskyv1alpha1.ConditionApplied)
+	if applied == nil || applied.Reason != teraskyv1alpha1.ReasonRevertFailed {
+		t.Fatalf("expected RevertFailed after partway failure, got %+v", applied)
+	}
+
+	if _, err := reconcileCRD(t, r, "cfg"); err != nil {
+		t.Fatalf("recovery reconcile: %v", err)
+	}
+	got = getCRDConfig(t, r, "cfg")
+	applied = meta.FindStatusCondition(got.Status.Conditions, teraskyv1alpha1.ConditionApplied)
+	if applied == nil || applied.Reason != teraskyv1alpha1.ReasonReverted {
+		t.Fatalf("expected Reason=Reverted after successful retry, got %+v", applied)
+	}
+	var liveCRD extv1.CustomResourceDefinition
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "foos.example.org"}, &liveCRD); err != nil {
+		t.Fatalf("getting CRD: %v", err)
+	}
+	if liveCRD.Spec.Conversion == nil || liveCRD.Spec.Conversion.Strategy != extv1.NoneConverter {
+		t.Fatalf("expected strategy=None after recovered FailClosed revert, got %+v", liveCRD.Spec.Conversion)
+	}
+}

--- a/internal/controller/cws_fanout.go
+++ b/internal/controller/cws_fanout.go
@@ -29,12 +29,52 @@ import (
 	"github.com/terasky-oss/declarative-conversion-operator/internal/assign"
 )
 
-// mapServerToAssignedXRDConfigs returns reconcile requests only for
-// XRDConversionConfigs that currently resolve to the changed
-// ConversionWebhookServer. Unrelated configs (assigned elsewhere, or
-// unresolvable) are skipped so a CWS event does not fan out to the entire
-// cluster inventory.
+// mapServerToAssignedXRDConfigs returns reconcile requests for
+// XRDConversionConfigs currently assigned to server under the live server
+// list. Used for Create / Delete / Generic events.
 func mapServerToAssignedXRDConfigs(ctx context.Context, c client.Client, server client.Object) ([]reconcile.Request, error) {
+	return mapXRDConfigsForServerViews(ctx, c, server.GetName(), serverAsCWS(server))
+}
+
+// mapServerTransitionToAssignedXRDConfigs returns the union of configs
+// assigned under the prior server view and the current server view. Update
+// events must use this so losing `spec.default` (or similar) still enqueues
+// configs that previously resolved to the changed server.
+func mapServerTransitionToAssignedXRDConfigs(ctx context.Context, c client.Client, oldObj, newObj client.Object) ([]reconcile.Request, error) {
+	name := ""
+	if newObj != nil {
+		name = newObj.GetName()
+	} else if oldObj != nil {
+		name = oldObj.GetName()
+	}
+	return mapXRDConfigsForServerViews(ctx, c, name, serverAsCWS(oldObj), serverAsCWS(newObj))
+}
+
+func mapServerToAssignedCRDConfigs(ctx context.Context, c client.Client, server client.Object) ([]reconcile.Request, error) {
+	return mapCRDConfigsForServerViews(ctx, c, server.GetName(), serverAsCWS(server))
+}
+
+func mapServerTransitionToAssignedCRDConfigs(ctx context.Context, c client.Client, oldObj, newObj client.Object) ([]reconcile.Request, error) {
+	name := ""
+	if newObj != nil {
+		name = newObj.GetName()
+	} else if oldObj != nil {
+		name = oldObj.GetName()
+	}
+	return mapCRDConfigsForServerViews(ctx, c, name, serverAsCWS(oldObj), serverAsCWS(newObj))
+}
+
+func serverAsCWS(obj client.Object) *teraskyv1alpha1.ConversionWebhookServer {
+	if obj == nil {
+		return nil
+	}
+	if s, ok := obj.(*teraskyv1alpha1.ConversionWebhookServer); ok {
+		return s
+	}
+	return nil
+}
+
+func mapXRDConfigsForServerViews(ctx context.Context, c client.Client, serverName string, views ...*teraskyv1alpha1.ConversionWebhookServer) ([]reconcile.Request, error) {
 	var list teraskyv1alpha1.XRDConversionConfigList
 	if err := c.List(ctx, &list); err != nil {
 		return nil, fmt.Errorf("listing XRDConversionConfigs for CWS fan-out: %w", err)
@@ -43,18 +83,26 @@ func mapServerToAssignedXRDConfigs(ctx context.Context, c client.Client, server 
 	if err := c.List(ctx, &servers); err != nil {
 		return nil, fmt.Errorf("listing ConversionWebhookServers for CWS fan-out: %w", err)
 	}
-	assigned := assign.ConfigsAssignedTo(list.Items, servers.Items, server.GetName())
-	reqs := make([]reconcile.Request, 0, len(assigned))
-	for _, cfg := range assigned {
-		reqs = append(reqs, reconcile.Request{NamespacedName: types.NamespacedName{Name: cfg.Name}})
+
+	seen := map[string]struct{}{}
+	var reqs []reconcile.Request
+	for _, view := range views {
+		if view == nil {
+			continue
+		}
+		for _, cfg := range assign.ConfigsAssignedTo(list.Items, serversWithView(servers.Items, view), serverName) {
+			if _, ok := seen[cfg.Name]; ok {
+				continue
+			}
+			seen[cfg.Name] = struct{}{}
+			reqs = append(reqs, reconcile.Request{NamespacedName: types.NamespacedName{Name: cfg.Name}})
+		}
 	}
 	sort.Slice(reqs, func(i, j int) bool { return reqs[i].Name < reqs[j].Name })
 	return reqs, nil
 }
 
-// mapServerToAssignedCRDConfigs is the CRDConversionConfig counterpart of
-// mapServerToAssignedXRDConfigs.
-func mapServerToAssignedCRDConfigs(ctx context.Context, c client.Client, server client.Object) ([]reconcile.Request, error) {
+func mapCRDConfigsForServerViews(ctx context.Context, c client.Client, serverName string, views ...*teraskyv1alpha1.ConversionWebhookServer) ([]reconcile.Request, error) {
 	var list teraskyv1alpha1.CRDConversionConfigList
 	if err := c.List(ctx, &list); err != nil {
 		return nil, fmt.Errorf("listing CRDConversionConfigs for CWS fan-out: %w", err)
@@ -63,11 +111,47 @@ func mapServerToAssignedCRDConfigs(ctx context.Context, c client.Client, server 
 	if err := c.List(ctx, &servers); err != nil {
 		return nil, fmt.Errorf("listing ConversionWebhookServers for CWS fan-out: %w", err)
 	}
-	assigned := assign.ConfigsAssignedTo(list.Items, servers.Items, server.GetName())
-	reqs := make([]reconcile.Request, 0, len(assigned))
-	for _, cfg := range assigned {
-		reqs = append(reqs, reconcile.Request{NamespacedName: types.NamespacedName{Name: cfg.Name}})
+
+	seen := map[string]struct{}{}
+	var reqs []reconcile.Request
+	for _, view := range views {
+		if view == nil {
+			continue
+		}
+		for _, cfg := range assign.ConfigsAssignedTo(list.Items, serversWithView(servers.Items, view), serverName) {
+			if _, ok := seen[cfg.Name]; ok {
+				continue
+			}
+			seen[cfg.Name] = struct{}{}
+			reqs = append(reqs, reconcile.Request{NamespacedName: types.NamespacedName{Name: cfg.Name}})
+		}
 	}
 	sort.Slice(reqs, func(i, j int) bool { return reqs[i].Name < reqs[j].Name })
 	return reqs, nil
+}
+
+// serversWithView returns a copy of live where the named server is replaced
+// by view (or appended if missing). If view.Spec.Default is true, other
+// servers' Default flags are cleared so assignment reflects the prior
+// exclusive-default world before a concurrent update made another server
+// the default.
+func serversWithView(live []teraskyv1alpha1.ConversionWebhookServer, view *teraskyv1alpha1.ConversionWebhookServer) []teraskyv1alpha1.ConversionWebhookServer {
+	out := make([]teraskyv1alpha1.ConversionWebhookServer, 0, len(live)+1)
+	found := false
+	for _, s := range live {
+		if s.Name == view.Name {
+			out = append(out, *view)
+			found = true
+			continue
+		}
+		cp := s
+		if view.Spec.Default {
+			cp.Spec.Default = false
+		}
+		out = append(out, cp)
+	}
+	if !found {
+		out = append(out, *view)
+	}
+	return out
 }

--- a/internal/controller/cws_fanout.go
+++ b/internal/controller/cws_fanout.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2026 The declarative-conversion-operator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	teraskyv1alpha1 "github.com/terasky-oss/declarative-conversion-operator/api/v1alpha1"
+	"github.com/terasky-oss/declarative-conversion-operator/internal/assign"
+)
+
+// mapServerToAssignedXRDConfigs returns reconcile requests only for
+// XRDConversionConfigs that currently resolve to the changed
+// ConversionWebhookServer. Unrelated configs (assigned elsewhere, or
+// unresolvable) are skipped so a CWS event does not fan out to the entire
+// cluster inventory.
+func mapServerToAssignedXRDConfigs(ctx context.Context, c client.Client, server client.Object) ([]reconcile.Request, error) {
+	var list teraskyv1alpha1.XRDConversionConfigList
+	if err := c.List(ctx, &list); err != nil {
+		return nil, fmt.Errorf("listing XRDConversionConfigs for CWS fan-out: %w", err)
+	}
+	var servers teraskyv1alpha1.ConversionWebhookServerList
+	if err := c.List(ctx, &servers); err != nil {
+		return nil, fmt.Errorf("listing ConversionWebhookServers for CWS fan-out: %w", err)
+	}
+	assigned := assign.ConfigsAssignedTo(list.Items, servers.Items, server.GetName())
+	reqs := make([]reconcile.Request, 0, len(assigned))
+	for _, cfg := range assigned {
+		reqs = append(reqs, reconcile.Request{NamespacedName: types.NamespacedName{Name: cfg.Name}})
+	}
+	sort.Slice(reqs, func(i, j int) bool { return reqs[i].Name < reqs[j].Name })
+	return reqs, nil
+}
+
+// mapServerToAssignedCRDConfigs is the CRDConversionConfig counterpart of
+// mapServerToAssignedXRDConfigs.
+func mapServerToAssignedCRDConfigs(ctx context.Context, c client.Client, server client.Object) ([]reconcile.Request, error) {
+	var list teraskyv1alpha1.CRDConversionConfigList
+	if err := c.List(ctx, &list); err != nil {
+		return nil, fmt.Errorf("listing CRDConversionConfigs for CWS fan-out: %w", err)
+	}
+	var servers teraskyv1alpha1.ConversionWebhookServerList
+	if err := c.List(ctx, &servers); err != nil {
+		return nil, fmt.Errorf("listing ConversionWebhookServers for CWS fan-out: %w", err)
+	}
+	assigned := assign.ConfigsAssignedTo(list.Items, servers.Items, server.GetName())
+	reqs := make([]reconcile.Request, 0, len(assigned))
+	for _, cfg := range assigned {
+		reqs = append(reqs, reconcile.Request{NamespacedName: types.NamespacedName{Name: cfg.Name}})
+	}
+	sort.Slice(reqs, func(i, j int) bool { return reqs[i].Name < reqs[j].Name })
+	return reqs, nil
+}

--- a/internal/controller/cws_fanout_test.go
+++ b/internal/controller/cws_fanout_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2026 The declarative-conversion-operator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	teraskyv1alpha1 "github.com/terasky-oss/declarative-conversion-operator/api/v1alpha1"
+	"github.com/terasky-oss/declarative-conversion-operator/internal/enqueue"
+)
+
+func TestMapServerToAssignedXRDConfigs_FiltersAndBoundsFanout(t *testing.T) {
+	srvA := &teraskyv1alpha1.ConversionWebhookServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "srv-a"},
+		Spec:       teraskyv1alpha1.ConversionWebhookServerSpec{Default: true},
+	}
+	srvB := &teraskyv1alpha1.ConversionWebhookServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "srv-b"},
+	}
+
+	const assignedN = 200
+	objs := []runtime.Object{srvA, srvB}
+	for i := 0; i < assignedN; i++ {
+		cfg := renameRuleXRDConfig(fmt.Sprintf("cfg-%03d", i), fmt.Sprintf("x%d.example.org", i))
+		// Default assignment → srv-a
+		objs = append(objs, cfg)
+	}
+	// 50 more configs explicitly pinned to srv-b — must not be enqueued for srv-a.
+	for i := 0; i < 50; i++ {
+		cfg := renameRuleXRDConfig(fmt.Sprintf("other-%03d", i), fmt.Sprintf("y%d.example.org", i))
+		cfg.Spec.WebhookServerRef = &teraskyv1alpha1.WebhookServerRef{Name: "srv-b"}
+		objs = append(objs, cfg)
+	}
+
+	c := newFakeClient(objs...).Build()
+	reqs, err := mapServerToAssignedXRDConfigs(context.Background(), c, srvA)
+	if err != nil {
+		t.Fatalf("mapServerToAssignedXRDConfigs: %v", err)
+	}
+	if len(reqs) != assignedN {
+		t.Fatalf("expected %d assigned configs enqueued for srv-a, got %d (unbounded all-configs fan-out would be %d)", assignedN, len(reqs), assignedN+50)
+	}
+
+	spread := enqueue.FanoutSpread(len(reqs), enqueue.CWSConfigEnqueueQPS)
+	if spread == 0 {
+		t.Fatalf("paced fan-out must spread %d requests over time at %.0f QPS", len(reqs), enqueue.CWSConfigEnqueueQPS)
+	}
+}
+
+func TestMapServerToAssignedCRDConfigs_FiltersAssignment(t *testing.T) {
+	srvA := &teraskyv1alpha1.ConversionWebhookServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "srv-a"},
+		Spec:       teraskyv1alpha1.ConversionWebhookServerSpec{Default: true},
+	}
+	srvB := &teraskyv1alpha1.ConversionWebhookServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "srv-b"},
+	}
+	cfgA := renameRuleCRDConfig("cfg-a", "a.example.org")
+	cfgB := renameRuleCRDConfig("cfg-b", "b.example.org")
+	cfgB.Spec.WebhookServerRef = &teraskyv1alpha1.WebhookServerRef{Name: "srv-b"}
+
+	c := newFakeClient(srvA, srvB, cfgA, cfgB).Build()
+	reqs, err := mapServerToAssignedCRDConfigs(context.Background(), c, srvA)
+	if err != nil {
+		t.Fatalf("mapServerToAssignedCRDConfigs: %v", err)
+	}
+	if len(reqs) != 1 || reqs[0].Name != "cfg-a" {
+		t.Fatalf("expected only cfg-a for srv-a, got %#v", reqs)
+	}
+}

--- a/internal/controller/cws_fanout_test.go
+++ b/internal/controller/cws_fanout_test.go
@@ -66,6 +66,55 @@ func TestMapServerToAssignedXRDConfigs_FiltersAndBoundsFanout(t *testing.T) {
 	}
 }
 
+func TestMapServerTransition_LosesDefault_StillEnqueuesPriorAssignments(t *testing.T) {
+	// Live list already reflects srv-a Default=false after the update;
+	// without the old view, unpinned configs would not enqueue for srv-a.
+	srvALive := &teraskyv1alpha1.ConversionWebhookServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "srv-a"},
+		Spec:       teraskyv1alpha1.ConversionWebhookServerSpec{Default: false},
+	}
+	srvB := &teraskyv1alpha1.ConversionWebhookServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "srv-b"},
+		Spec:       teraskyv1alpha1.ConversionWebhookServerSpec{Default: true},
+	}
+	srvAOld := srvALive.DeepCopy()
+	srvAOld.Spec.Default = true
+
+	cfg := renameRuleXRDConfig("cfg-default", "xfoos.example.org") // unpinned → follows default
+	c := newFakeClient(srvALive, srvB, cfg).Build()
+
+	reqs, err := mapServerTransitionToAssignedXRDConfigs(context.Background(), c, srvAOld, srvALive)
+	if err != nil {
+		t.Fatalf("transition map: %v", err)
+	}
+	if len(reqs) != 1 || reqs[0].Name != "cfg-default" {
+		t.Fatalf("expected cfg-default enqueued from prior default assignment, got %#v", reqs)
+	}
+}
+
+func TestMapServerToAssigned_DeleteUsesDeletedObjectView(t *testing.T) {
+	// Live list no longer contains srv-a; the delete event still carries it.
+	srvB := &teraskyv1alpha1.ConversionWebhookServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "srv-b"},
+		Spec:       teraskyv1alpha1.ConversionWebhookServerSpec{Default: true},
+	}
+	deleted := &teraskyv1alpha1.ConversionWebhookServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "srv-a"},
+		Spec:       teraskyv1alpha1.ConversionWebhookServerSpec{Default: false},
+	}
+	cfg := renameRuleXRDConfig("cfg-explicit", "xfoos.example.org")
+	cfg.Spec.WebhookServerRef = &teraskyv1alpha1.WebhookServerRef{Name: "srv-a"}
+
+	c := newFakeClient(srvB, cfg).Build()
+	reqs, err := mapServerToAssignedXRDConfigs(context.Background(), c, deleted)
+	if err != nil {
+		t.Fatalf("delete map: %v", err)
+	}
+	if len(reqs) != 1 || reqs[0].Name != "cfg-explicit" {
+		t.Fatalf("expected cfg-explicit enqueued for deleted server, got %#v", reqs)
+	}
+}
+
 func TestMapServerToAssignedCRDConfigs_FiltersAssignment(t *testing.T) {
 	srvA := &teraskyv1alpha1.ConversionWebhookServer{
 		ObjectMeta: metav1.ObjectMeta{Name: "srv-a"},

--- a/internal/controller/watchmap_error_test.go
+++ b/internal/controller/watchmap_error_test.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2026 The declarative-conversion-operator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	teraskyv1alpha1 "github.com/terasky-oss/declarative-conversion-operator/api/v1alpha1"
+	"github.com/terasky-oss/declarative-conversion-operator/internal/watchmap"
+)
+
+func TestMapServerToAssignedConfigs_ListErrorSurfaced(t *testing.T) {
+	var hooked string
+	var hookedErr error
+	prev := watchmap.ErrorHook
+	watchmap.ErrorHook = func(mapFunc string, err error) {
+		hooked = mapFunc
+		hookedErr = err
+	}
+	t.Cleanup(func() { watchmap.ErrorHook = prev })
+
+	srv := &teraskyv1alpha1.ConversionWebhookServer{ObjectMeta: metav1.ObjectMeta{Name: "srv"}}
+	c := newFakeClient(srv).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				return fmt.Errorf("injected list failure")
+			},
+		}).
+		Build()
+	r := &XRDConversionConfigReconciler{Client: c}
+
+	reqs := r.mapServerToAssignedConfigs(context.Background(), srv)
+	if len(reqs) != 0 {
+		t.Fatalf("expected empty requests on list failure, got %#v", reqs)
+	}
+	if hooked != "xrdconversionconfig.mapServerToAssignedConfigs" {
+		t.Fatalf("expected ErrorHook for mapServerToAssignedConfigs, got %q", hooked)
+	}
+	if hookedErr == nil || hookedErr.Error() == "" {
+		t.Fatalf("expected ErrorHook to receive the list error")
+	}
+}
+
+func TestMapXRDToConfigs_ListErrorSurfaced(t *testing.T) {
+	var hooked string
+	prev := watchmap.ErrorHook
+	watchmap.ErrorHook = func(mapFunc string, err error) { hooked = mapFunc }
+	t.Cleanup(func() { watchmap.ErrorHook = prev })
+
+	xrd := establishedXRD("xfoos.example.org")
+	c := newFakeClient().
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				return fmt.Errorf("injected list failure")
+			},
+		}).
+		Build()
+	r := &XRDConversionConfigReconciler{Client: c}
+	reqs := r.mapXRDToConfigs(context.Background(), xrd)
+	if len(reqs) != 0 {
+		t.Fatalf("expected empty requests on list failure, got %#v", reqs)
+	}
+	if hooked != "xrdconversionconfig.mapXRDToConfigs" {
+		t.Fatalf("expected ErrorHook for mapXRDToConfigs, got %q", hooked)
+	}
+}
+
+func TestEnqueueAllServers_ListErrorSurfaced(t *testing.T) {
+	var hooked string
+	prev := watchmap.ErrorHook
+	watchmap.ErrorHook = func(mapFunc string, err error) { hooked = mapFunc }
+	t.Cleanup(func() { watchmap.ErrorHook = prev })
+
+	c := newFakeClient().
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				return fmt.Errorf("injected list failure")
+			},
+		}).
+		Build()
+	fn := enqueueAllServers(c)
+	reqs := fn(context.Background(), &teraskyv1alpha1.XRDConversionConfig{})
+	if len(reqs) != 0 {
+		t.Fatalf("expected empty requests on list failure, got %#v", reqs)
+	}
+	if hooked != "conversionwebhookserver.enqueueAllServers" {
+		t.Fatalf("expected ErrorHook for enqueueAllServers, got %q", hooked)
+	}
+}
+
+// Ensure the interceptor import's runtime Object usage stays compile-clean
+// when only client.ObjectList is referenced above.
+var _ runtime.Object = &teraskyv1alpha1.XRDConversionConfig{}

--- a/internal/controller/xrdconversionconfig_controller.go
+++ b/internal/controller/xrdconversionconfig_controller.go
@@ -40,6 +40,7 @@ import (
 	teraskyv1alpha1 "github.com/terasky-oss/declarative-conversion-operator/api/v1alpha1"
 	"github.com/terasky-oss/declarative-conversion-operator/internal/assign"
 	"github.com/terasky-oss/declarative-conversion-operator/internal/enqueue"
+	"github.com/terasky-oss/declarative-conversion-operator/internal/watchmap"
 	"github.com/terasky-oss/declarative-conversion-operator/pkg/engine"
 	"github.com/terasky-oss/declarative-conversion-operator/pkg/xrdadapter"
 )
@@ -570,7 +571,7 @@ func (r *XRDConversionConfigReconciler) SetupWithManager(mgr ctrl.Manager) error
 func (r *XRDConversionConfigReconciler) mapXRDToConfigs(ctx context.Context, obj client.Object) []reconcile.Request {
 	var list teraskyv1alpha1.XRDConversionConfigList
 	if err := r.List(ctx, &list, client.MatchingFields{TargetXRDNameIndex: obj.GetName()}); err != nil {
-		return nil
+		return watchmap.ListError(ctx, "xrdconversionconfig.mapXRDToConfigs", err)
 	}
 	reqs := make([]reconcile.Request, 0, len(list.Items))
 	for _, c := range list.Items {
@@ -582,7 +583,7 @@ func (r *XRDConversionConfigReconciler) mapXRDToConfigs(ctx context.Context, obj
 func (r *XRDConversionConfigReconciler) mapServerToAssignedConfigs(ctx context.Context, obj client.Object) []reconcile.Request {
 	reqs, err := mapServerToAssignedXRDConfigs(ctx, r.Client, obj)
 	if err != nil {
-		return nil
+		return watchmap.ListError(ctx, "xrdconversionconfig.mapServerToAssignedConfigs", err)
 	}
 	return reqs
 }

--- a/internal/controller/xrdconversionconfig_controller.go
+++ b/internal/controller/xrdconversionconfig_controller.go
@@ -21,7 +21,6 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
-	"sort"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -40,6 +39,7 @@ import (
 
 	teraskyv1alpha1 "github.com/terasky-oss/declarative-conversion-operator/api/v1alpha1"
 	"github.com/terasky-oss/declarative-conversion-operator/internal/assign"
+	"github.com/terasky-oss/declarative-conversion-operator/internal/enqueue"
 	"github.com/terasky-oss/declarative-conversion-operator/pkg/engine"
 	"github.com/terasky-oss/declarative-conversion-operator/pkg/xrdadapter"
 )
@@ -543,9 +543,8 @@ func (r *XRDConversionConfigReconciler) patchStatus(ctx context.Context, orig, c
 
 // SetupWithManager wires up watches: the primary XRDConversionConfig
 // resource, plus the target XRD (via a field index mapping XRD name back
-// to referencing configs) and ConversionWebhookServer (any change
-// re-evaluates every config, since server readiness/assignment affects all
-// of them and this is a low-QPS, admin-frequency object).
+// to referencing configs) and ConversionWebhookServer (changes enqueue
+// only configs assigned to that server, paced at enqueue.CWSConfigEnqueueQPS).
 func (r *XRDConversionConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &teraskyv1alpha1.XRDConversionConfig{}, TargetXRDNameIndex, func(obj client.Object) []string {
 		cfg := obj.(*teraskyv1alpha1.XRDConversionConfig)
@@ -563,7 +562,7 @@ func (r *XRDConversionConfigReconciler) SetupWithManager(mgr ctrl.Manager) error
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&teraskyv1alpha1.XRDConversionConfig{}).
 		Watches(xrdObj, handler.EnqueueRequestsFromMapFunc(r.mapXRDToConfigs)).
-		Watches(&teraskyv1alpha1.ConversionWebhookServer{}, handler.EnqueueRequestsFromMapFunc(r.mapAnyServerToAllConfigs)).
+		Watches(&teraskyv1alpha1.ConversionWebhookServer{}, enqueue.PacedMapFunc(r.mapServerToAssignedConfigs, enqueue.CWSConfigEnqueueQPS)).
 		Named("xrdconversionconfig").
 		Complete(r)
 }
@@ -580,15 +579,10 @@ func (r *XRDConversionConfigReconciler) mapXRDToConfigs(ctx context.Context, obj
 	return reqs
 }
 
-func (r *XRDConversionConfigReconciler) mapAnyServerToAllConfigs(ctx context.Context, _ client.Object) []reconcile.Request {
-	var list teraskyv1alpha1.XRDConversionConfigList
-	if err := r.List(ctx, &list); err != nil {
+func (r *XRDConversionConfigReconciler) mapServerToAssignedConfigs(ctx context.Context, obj client.Object) []reconcile.Request {
+	reqs, err := mapServerToAssignedXRDConfigs(ctx, r.Client, obj)
+	if err != nil {
 		return nil
 	}
-	reqs := make([]reconcile.Request, 0, len(list.Items))
-	for _, c := range list.Items {
-		reqs = append(reqs, reconcile.Request{NamespacedName: types.NamespacedName{Name: c.Name}})
-	}
-	sort.Slice(reqs, func(i, j int) bool { return reqs[i].Name < reqs[j].Name })
 	return reqs
 }

--- a/internal/controller/xrdconversionconfig_controller.go
+++ b/internal/controller/xrdconversionconfig_controller.go
@@ -563,7 +563,7 @@ func (r *XRDConversionConfigReconciler) SetupWithManager(mgr ctrl.Manager) error
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&teraskyv1alpha1.XRDConversionConfig{}).
 		Watches(xrdObj, handler.EnqueueRequestsFromMapFunc(r.mapXRDToConfigs)).
-		Watches(&teraskyv1alpha1.ConversionWebhookServer{}, enqueue.PacedMapFunc(r.mapServerToAssignedConfigs, enqueue.CWSConfigEnqueueQPS)).
+		Watches(&teraskyv1alpha1.ConversionWebhookServer{}, enqueue.PacedMapFuncs(r.mapServerToAssignedConfigs, r.mapServerTransitionToAssignedConfigs, enqueue.CWSConfigEnqueueQPS)).
 		Named("xrdconversionconfig").
 		Complete(r)
 }
@@ -584,6 +584,14 @@ func (r *XRDConversionConfigReconciler) mapServerToAssignedConfigs(ctx context.C
 	reqs, err := mapServerToAssignedXRDConfigs(ctx, r.Client, obj)
 	if err != nil {
 		return watchmap.ListError(ctx, "xrdconversionconfig.mapServerToAssignedConfigs", err)
+	}
+	return reqs
+}
+
+func (r *XRDConversionConfigReconciler) mapServerTransitionToAssignedConfigs(ctx context.Context, oldObj, newObj client.Object) []reconcile.Request {
+	reqs, err := mapServerTransitionToAssignedXRDConfigs(ctx, r.Client, oldObj, newObj)
+	if err != nil {
+		return watchmap.ListError(ctx, "xrdconversionconfig.mapServerTransitionToAssignedConfigs", err)
 	}
 	return reqs
 }

--- a/internal/controller/xrdconversionconfig_controller_failure_test.go
+++ b/internal/controller/xrdconversionconfig_controller_failure_test.go
@@ -1,0 +1,353 @@
+/*
+Copyright 2026 The declarative-conversion-operator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	teraskyv1alpha1 "github.com/terasky-oss/declarative-conversion-operator/api/v1alpha1"
+	"github.com/terasky-oss/declarative-conversion-operator/pkg/xrdadapter"
+)
+
+// Phase 2.1 failure-path coverage for FailClosed / KeepServingStale.
+// These use the fake client + interceptors (no envtest) to exercise the
+// branches the architecture safety table claims exist: mid-path revert
+// failure, crash between compile and patch, and schema drift mid-lifecycle.
+
+func TestXRDReconcile_CrashBeforePatch_RestartsAndApplies(t *testing.T) {
+	xrd := establishedXRD("xfoos.example.org")
+	cfg := renameRuleXRDConfig("cfg", "xfoos.example.org")
+	server, secret := readyServer("srv")
+
+	var applyCalls atomic.Int32
+	c := newFakeClient(cfg, server, secret).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Apply: func(ctx context.Context, c client.WithWatch, obj runtime.ApplyConfiguration, opts ...client.ApplyOption) error {
+				if applyCalls.Add(1) == 1 {
+					// Simulate a controller crash after analysis/compile
+					// succeeded but before the XRD conversion patch landed.
+					return fmt.Errorf("injected crash before XRD patch")
+				}
+				return c.Apply(ctx, obj, opts...)
+			},
+		}).
+		Build()
+	if err := c.Create(context.Background(), xrd); err != nil {
+		t.Fatalf("creating XRD fixture: %v", err)
+	}
+	r := &XRDConversionConfigReconciler{Client: c, DefaultServerNamespace: "operator-ns"}
+
+	// First reconcile adds the finalizer and continues into apply; the
+	// injected Apply failure simulates a crash after compile/validation.
+	_, err := reconcileXRD(t, r, "cfg")
+	if err == nil {
+		t.Fatalf("expected reconcile error when XRD patch crashes")
+	}
+	got := getXRDConfig(t, r, "cfg")
+	if got.Status.Phase == teraskyv1alpha1.PhaseApplied {
+		t.Fatalf("must not report Applied after a failed patch; phase=%q", got.Status.Phase)
+	}
+	liveXRD := &unstructured.Unstructured{}
+	liveXRD.SetGroupVersionKind(xrdadapter.GroupVersionKind)
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "xfoos.example.org"}, liveXRD); err != nil {
+		t.Fatalf("getting XRD: %v", err)
+	}
+	if strategy, found := stringField(liveXRD.Object, "spec", "conversion", "strategy"); found && strategy == "Webhook" {
+		t.Fatalf("XRD must remain unpatched after crash-before-patch")
+	}
+
+	// Restart: same reconciler, working Apply — completes to Applied.
+	if _, err := reconcileXRD(t, r, "cfg"); err != nil {
+		t.Fatalf("restart reconcile: %v", err)
+	}
+	got = getXRDConfig(t, r, "cfg")
+	if got.Status.Phase != teraskyv1alpha1.PhaseApplied {
+		t.Fatalf("expected Applied after restart, got %q (%s)", got.Status.Phase, got.Status.Message)
+	}
+}
+
+func TestXRDReconcile_CrashAfterPatchBeforeStatus_RestartsIdempotently(t *testing.T) {
+	xrd := establishedXRD("xfoos.example.org")
+	cfg := renameRuleXRDConfig("cfg", "xfoos.example.org")
+	server, secret := readyServer("srv")
+
+	var statusPatches atomic.Int32
+	c := newFakeClient(cfg, server, secret).
+		WithInterceptorFuncs(interceptor.Funcs{
+			SubResourcePatch: func(ctx context.Context, c client.Client, subResourceName string, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+				if subResourceName == "status" {
+					if statusPatches.Add(1) == 1 {
+						// Patch landed on the XRD; crash before status
+						// ObservedGeneration/Phase=Applied is persisted.
+						return fmt.Errorf("injected crash before status Applied")
+					}
+				}
+				return c.SubResource(subResourceName).Patch(ctx, obj, patch, opts...)
+			},
+		}).
+		Build()
+	if err := c.Create(context.Background(), xrd); err != nil {
+		t.Fatalf("creating XRD fixture: %v", err)
+	}
+	r := &XRDConversionConfigReconciler{Client: c, DefaultServerNamespace: "operator-ns"}
+
+	// Finalizer + apply succeed; status persistence crashes — classic
+	// "target patched, ObservedGeneration/Phase not yet Applied" window.
+	_, err := reconcileXRD(t, r, "cfg")
+	if err == nil {
+		t.Fatalf("expected error when status patch crashes after XRD apply")
+	}
+	got := getXRDConfig(t, r, "cfg")
+	if got.Status.Phase == teraskyv1alpha1.PhaseApplied {
+		t.Fatalf("status must not show Applied after crashed status write; phase=%q", got.Status.Phase)
+	}
+	liveXRD := &unstructured.Unstructured{}
+	liveXRD.SetGroupVersionKind(xrdadapter.GroupVersionKind)
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "xfoos.example.org"}, liveXRD); err != nil {
+		t.Fatalf("getting XRD: %v", err)
+	}
+	strategy, found := stringField(liveXRD.Object, "spec", "conversion", "strategy")
+	if !found || strategy != "Webhook" {
+		t.Fatalf("expected XRD already patched to Webhook before the status crash, found=%v strategy=%q", found, strategy)
+	}
+
+	// Restart reconciles idempotently: re-applies SSA and finally persists Applied.
+	if _, err := reconcileXRD(t, r, "cfg"); err != nil {
+		t.Fatalf("restart reconcile: %v", err)
+	}
+	got = getXRDConfig(t, r, "cfg")
+	if got.Status.Phase != teraskyv1alpha1.PhaseApplied {
+		t.Fatalf("expected Applied after restart, got %q (%s)", got.Status.Phase, got.Status.Message)
+	}
+}
+
+func TestXRDReconcile_SchemaDriftMidLifecycle_KeepServingStale(t *testing.T) {
+	xrd := establishedXRD("xfoos.example.org")
+	cfg := renameRuleXRDConfig("cfg", "xfoos.example.org")
+	cfg.Spec.DriftPolicy = teraskyv1alpha1.DriftPolicyKeepServingStale
+	server, secret := readyServer("srv")
+
+	c := newFakeClient(cfg, server, secret).Build()
+	if err := c.Create(context.Background(), xrd); err != nil {
+		t.Fatalf("creating XRD fixture: %v", err)
+	}
+	r := &XRDConversionConfigReconciler{Client: c, DefaultServerNamespace: "operator-ns"}
+
+	if _, err := reconcileXRD(t, r, "cfg"); err != nil {
+		t.Fatalf("finalizer reconcile: %v", err)
+	}
+	if _, err := reconcileXRD(t, r, "cfg"); err != nil {
+		t.Fatalf("apply reconcile: %v", err)
+	}
+	if got := getXRDConfig(t, r, "cfg"); got.Status.Phase != teraskyv1alpha1.PhaseApplied {
+		t.Fatalf("precondition: expected Applied, got %q", got.Status.Phase)
+	}
+
+	// Drift the live XRD schema mid-lifecycle (hub field disappears) while
+	// the config rules stay unchanged — the failure branch the drift
+	// policies exist to handle.
+	liveXRD := &unstructured.Unstructured{}
+	liveXRD.SetGroupVersionKind(xrdadapter.GroupVersionKind)
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "xfoos.example.org"}, liveXRD); err != nil {
+		t.Fatalf("getting XRD: %v", err)
+	}
+	versions, _, _ := unstructured.NestedSlice(liveXRD.Object, "spec", "versions")
+	hub := versions[0].(map[string]any)
+	_ = unstructured.SetNestedMap(hub, map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"spec": map[string]any{"type": "object", "properties": map[string]any{
+				// hub no longer has spec.size — rename rule is now invalid
+				"capacity": map[string]any{"type": "string"},
+			}},
+		},
+	}, "schema", "openAPIV3Schema")
+	versions[0] = hub
+	if err := unstructured.SetNestedSlice(liveXRD.Object, versions, "spec", "versions"); err != nil {
+		t.Fatalf("mutating XRD schema: %v", err)
+	}
+	liveXRD.SetGeneration(2)
+	if err := r.Update(context.Background(), liveXRD); err != nil {
+		t.Fatalf("updating drifted XRD: %v", err)
+	}
+
+	if _, err := reconcileXRD(t, r, "cfg"); err != nil {
+		t.Fatalf("drift reconcile: %v", err)
+	}
+	got := getXRDConfig(t, r, "cfg")
+	if got.Status.Phase != teraskyv1alpha1.PhaseStale {
+		t.Fatalf("expected Stale under KeepServingStale schema drift, got %q (%s)", got.Status.Phase, got.Status.Message)
+	}
+	if !meta.IsStatusConditionTrue(got.Status.Conditions, teraskyv1alpha1.ConditionStale) {
+		t.Fatalf("expected ConditionStale=True, got %+v", got.Status.Conditions)
+	}
+	patched := &unstructured.Unstructured{}
+	patched.SetGroupVersionKind(xrdadapter.GroupVersionKind)
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "xfoos.example.org"}, patched); err != nil {
+		t.Fatalf("getting XRD after drift: %v", err)
+	}
+	strategy, found := stringField(patched.Object, "spec", "conversion", "strategy")
+	if !found || strategy != "Webhook" {
+		t.Fatalf("KeepServingStale must leave webhook conversion in place, found=%v strategy=%q", found, strategy)
+	}
+}
+
+func TestXRDReconcile_SchemaDriftMidLifecycle_FailClosedReverts(t *testing.T) {
+	xrd := establishedXRD("xfoos.example.org")
+	cfg := renameRuleXRDConfig("cfg", "xfoos.example.org")
+	cfg.Spec.DriftPolicy = teraskyv1alpha1.DriftPolicyFailClosed
+	server, secret := readyServer("srv")
+
+	c := newFakeClient(cfg, server, secret).Build()
+	if err := c.Create(context.Background(), xrd); err != nil {
+		t.Fatalf("creating XRD fixture: %v", err)
+	}
+	r := &XRDConversionConfigReconciler{Client: c, DefaultServerNamespace: "operator-ns"}
+
+	if _, err := reconcileXRD(t, r, "cfg"); err != nil {
+		t.Fatalf("finalizer reconcile: %v", err)
+	}
+	if _, err := reconcileXRD(t, r, "cfg"); err != nil {
+		t.Fatalf("apply reconcile: %v", err)
+	}
+
+	liveXRD := &unstructured.Unstructured{}
+	liveXRD.SetGroupVersionKind(xrdadapter.GroupVersionKind)
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "xfoos.example.org"}, liveXRD); err != nil {
+		t.Fatalf("getting XRD: %v", err)
+	}
+	versions, _, _ := unstructured.NestedSlice(liveXRD.Object, "spec", "versions")
+	hub := versions[0].(map[string]any)
+	_ = unstructured.SetNestedMap(hub, map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"spec": map[string]any{"type": "object", "properties": map[string]any{
+				"capacity": map[string]any{"type": "string"},
+			}},
+		},
+	}, "schema", "openAPIV3Schema")
+	versions[0] = hub
+	if err := unstructured.SetNestedSlice(liveXRD.Object, versions, "spec", "versions"); err != nil {
+		t.Fatalf("mutating XRD schema: %v", err)
+	}
+	liveXRD.SetGeneration(2)
+	if err := r.Update(context.Background(), liveXRD); err != nil {
+		t.Fatalf("updating drifted XRD: %v", err)
+	}
+
+	if _, err := reconcileXRD(t, r, "cfg"); err != nil {
+		t.Fatalf("drift reconcile: %v", err)
+	}
+	got := getXRDConfig(t, r, "cfg")
+	if got.Status.Phase != teraskyv1alpha1.PhaseFailed {
+		t.Fatalf("expected Failed under FailClosed schema drift, got %q (%s)", got.Status.Phase, got.Status.Message)
+	}
+	applied := meta.FindStatusCondition(got.Status.Conditions, teraskyv1alpha1.ConditionApplied)
+	if applied == nil || applied.Reason != teraskyv1alpha1.ReasonReverted {
+		t.Fatalf("expected Reason=Reverted, got %+v", applied)
+	}
+	patched := &unstructured.Unstructured{}
+	patched.SetGroupVersionKind(xrdadapter.GroupVersionKind)
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "xfoos.example.org"}, patched); err != nil {
+		t.Fatalf("getting XRD after FailClosed: %v", err)
+	}
+	strategy, found := stringField(patched.Object, "spec", "conversion", "strategy")
+	if !found || strategy != "None" {
+		t.Fatalf("FailClosed must revert to strategy=None, found=%v strategy=%q", found, strategy)
+	}
+}
+
+func TestXRDReconcile_FailClosed_PartwayRevertThenRecover(t *testing.T) {
+	// Builds on Phase 0.5: first FailClosed revert fails mid-path; a later
+	// reconcile with a working Apply finishes the tear-down honestly.
+	xrd := establishedXRD("xfoos.example.org")
+	if err := unstructured.SetNestedMap(xrd.Object, map[string]any{
+		"strategy": "Webhook",
+		"webhook":  map[string]any{"clientConfig": map[string]any{"url": "https://example.invalid/convert"}},
+	}, "spec", "conversion"); err != nil {
+		t.Fatalf("seeding webhook conversion: %v", err)
+	}
+	cfg := renameRuleXRDConfig("cfg", "xfoos.example.org")
+	cfg.Spec.DriftPolicy = teraskyv1alpha1.DriftPolicyFailClosed
+	cfg.Status.Phase = teraskyv1alpha1.PhaseApplied
+	meta.SetStatusCondition(&cfg.Status.Conditions, metav1.Condition{
+		Type: teraskyv1alpha1.ConditionApplied, Status: metav1.ConditionTrue, Reason: "Applied", Message: "previously applied",
+	})
+	controllerutil.AddFinalizer(cfg, teraskyv1alpha1.XRDConversionConfigFinalizer)
+	server, secret := readyServer("srv")
+
+	var applyCalls atomic.Int32
+	c := newFakeClient(cfg, server, secret).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Apply: func(ctx context.Context, c client.WithWatch, obj runtime.ApplyConfiguration, opts ...client.ApplyOption) error {
+				if applyCalls.Add(1) == 1 {
+					return fmt.Errorf("injected partway revert failure")
+				}
+				return c.Apply(ctx, obj, opts...)
+			},
+		}).
+		Build()
+	if err := c.Create(context.Background(), xrd); err != nil {
+		t.Fatalf("creating XRD fixture: %v", err)
+	}
+	r := &XRDConversionConfigReconciler{Client: c, DefaultServerNamespace: "operator-ns"}
+
+	live := getXRDConfig(t, r, "cfg")
+	live.Spec.Spokes[0].Rules[0].FieldRename.HubPath = "spec.doesNotExist"
+	if err := r.Update(context.Background(), live); err != nil {
+		t.Fatalf("updating config: %v", err)
+	}
+
+	if _, err := reconcileXRD(t, r, "cfg"); err == nil {
+		t.Fatalf("expected partway revert to return an error")
+	}
+	got := getXRDConfig(t, r, "cfg")
+	applied := meta.FindStatusCondition(got.Status.Conditions, teraskyv1alpha1.ConditionApplied)
+	if applied == nil || applied.Reason != teraskyv1alpha1.ReasonRevertFailed {
+		t.Fatalf("expected RevertFailed after partway failure, got %+v", applied)
+	}
+
+	if _, err := reconcileXRD(t, r, "cfg"); err != nil {
+		t.Fatalf("recovery reconcile: %v", err)
+	}
+	got = getXRDConfig(t, r, "cfg")
+	applied = meta.FindStatusCondition(got.Status.Conditions, teraskyv1alpha1.ConditionApplied)
+	if applied == nil || applied.Reason != teraskyv1alpha1.ReasonReverted {
+		t.Fatalf("expected Reason=Reverted after successful retry, got %+v", applied)
+	}
+	liveXRD := &unstructured.Unstructured{}
+	liveXRD.SetGroupVersionKind(xrdadapter.GroupVersionKind)
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "xfoos.example.org"}, liveXRD); err != nil {
+		t.Fatalf("getting XRD: %v", err)
+	}
+	strategy, found := stringField(liveXRD.Object, "spec", "conversion", "strategy")
+	if !found || strategy != "None" {
+		t.Fatalf("expected strategy=None after recovered FailClosed revert, found=%v strategy=%q", found, strategy)
+	}
+}

--- a/internal/enqueue/paced.go
+++ b/internal/enqueue/paced.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2026 The declarative-conversion-operator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package enqueue provides shared watch-mapping helpers for controller
+// fan-out, notably paced enqueue of ConversionWebhookServer changes onto
+// the configs that resolve to them.
+package enqueue
+
+import (
+	"context"
+	"time"
+
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// CWSConfigEnqueueQPS is the documented enqueue pacing for
+// ConversionWebhookServer → config fan-out. Request i is delayed by
+// i/QPS seconds, so N=200 assigned configs spreads over 4s at the default
+// 50 QPS instead of an immediate workqueue burst. Feeds Phase 9 load e2e.
+const CWSConfigEnqueueQPS = 50.0
+
+// MapFunc is the same signature as controller-runtime's handler.MapFunc.
+type MapFunc func(context.Context, client.Object) []reconcile.Request
+
+// PacedMapFunc returns an EventHandler that runs fn then enqueues the
+// resulting requests with staggered AddAfter delays at the given QPS.
+// qps <= 0 disables pacing (immediate Add for every request).
+func PacedMapFunc(fn MapFunc, qps float64) handler.EventHandler {
+	enqueue := func(ctx context.Context, obj client.Object, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+		reqs := fn(ctx, obj)
+		if qps <= 0 {
+			for _, req := range reqs {
+				q.Add(req)
+			}
+			return
+		}
+		for i, req := range reqs {
+			delay := time.Duration(float64(i) / qps * float64(time.Second))
+			if delay <= 0 {
+				q.Add(req)
+				continue
+			}
+			q.AddAfter(req, delay)
+		}
+	}
+	return handler.Funcs{
+		CreateFunc: func(ctx context.Context, e event.CreateEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+			enqueue(ctx, e.Object, q)
+		},
+		UpdateFunc: func(ctx context.Context, e event.UpdateEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+			enqueue(ctx, e.ObjectNew, q)
+		},
+		DeleteFunc: func(ctx context.Context, e event.DeleteEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+			enqueue(ctx, e.Object, q)
+		},
+		GenericFunc: func(ctx context.Context, e event.GenericEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+			enqueue(ctx, e.Object, q)
+		},
+	}
+}
+
+// FanoutSpread returns how long the last request is delayed for n
+// requests at the given QPS. Used by tests and docs.
+func FanoutSpread(n int, qps float64) time.Duration {
+	if n <= 1 || qps <= 0 {
+		return 0
+	}
+	return time.Duration(float64(n-1) / qps * float64(time.Second))
+}

--- a/internal/enqueue/paced.go
+++ b/internal/enqueue/paced.go
@@ -36,15 +36,20 @@ import (
 // 50 QPS instead of an immediate workqueue burst. Feeds Phase 9 load e2e.
 const CWSConfigEnqueueQPS = 50.0
 
-// MapFunc is the same signature as controller-runtime's handler.MapFunc.
+// MapFunc maps a single object (Create / Generic) to reconcile requests.
 type MapFunc func(context.Context, client.Object) []reconcile.Request
 
-// PacedMapFunc returns an EventHandler that runs fn then enqueues the
-// resulting requests with staggered AddAfter delays at the given QPS.
+// UpdateMapFunc maps an Update event using both old and new objects so
+// callers can enqueue the union of prior and current assignments.
+type UpdateMapFunc func(ctx context.Context, oldObj, newObj client.Object) []reconcile.Request
+
+// PacedMapFuncs returns an EventHandler that paces enqueue of mapped
+// requests at the given QPS. Update events use updateFn (old+new);
+// Create/Delete/Generic use mapFn on the single available object.
 // qps <= 0 disables pacing (immediate Add for every request).
-func PacedMapFunc(fn MapFunc, qps float64) handler.EventHandler {
-	enqueue := func(ctx context.Context, obj client.Object, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-		reqs := fn(ctx, obj)
+func PacedMapFuncs(mapFn MapFunc, updateFn UpdateMapFunc, qps float64) handler.EventHandler {
+	enqueue := func(reqs []reconcile.Request, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+		reqs = dedupeRequests(reqs)
 		if qps <= 0 {
 			for _, req := range reqs {
 				q.Add(req)
@@ -62,16 +67,16 @@ func PacedMapFunc(fn MapFunc, qps float64) handler.EventHandler {
 	}
 	return handler.Funcs{
 		CreateFunc: func(ctx context.Context, e event.CreateEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-			enqueue(ctx, e.Object, q)
+			enqueue(mapFn(ctx, e.Object), q)
 		},
 		UpdateFunc: func(ctx context.Context, e event.UpdateEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-			enqueue(ctx, e.ObjectNew, q)
+			enqueue(updateFn(ctx, e.ObjectOld, e.ObjectNew), q)
 		},
 		DeleteFunc: func(ctx context.Context, e event.DeleteEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-			enqueue(ctx, e.Object, q)
+			enqueue(mapFn(ctx, e.Object), q)
 		},
 		GenericFunc: func(ctx context.Context, e event.GenericEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-			enqueue(ctx, e.Object, q)
+			enqueue(mapFn(ctx, e.Object), q)
 		},
 	}
 }
@@ -83,4 +88,21 @@ func FanoutSpread(n int, qps float64) time.Duration {
 		return 0
 	}
 	return time.Duration(float64(n-1) / qps * float64(time.Second))
+}
+
+func dedupeRequests(reqs []reconcile.Request) []reconcile.Request {
+	if len(reqs) < 2 {
+		return reqs
+	}
+	seen := make(map[string]struct{}, len(reqs))
+	out := make([]reconcile.Request, 0, len(reqs))
+	for _, req := range reqs {
+		key := req.Namespace + "/" + req.Name
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, req)
+	}
+	return out
 }

--- a/internal/enqueue/paced_test.go
+++ b/internal/enqueue/paced_test.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2026 The declarative-conversion-operator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package enqueue
+
+import (
+	"testing"
+	"time"
+)
+
+func TestFanoutSpread_NoUnboundedBurst(t *testing.T) {
+	const n = 200
+	spread := FanoutSpread(n, CWSConfigEnqueueQPS)
+	// At 50 QPS, 200 configs take (199/50)s ≈ 3.98s — must not be an
+	// instantaneous burst (spread == 0) and must stay well under a minute.
+	if spread == 0 {
+		t.Fatalf("expected non-zero spread for %d configs at %.0f QPS", n, CWSConfigEnqueueQPS)
+	}
+	want := time.Duration(float64(n-1) / CWSConfigEnqueueQPS * float64(time.Second))
+	if spread != want {
+		t.Fatalf("spread=%v, want %v", spread, want)
+	}
+	if spread > 10*time.Second {
+		t.Fatalf("spread %v is unexpectedly large for Phase 9's ~200-config case", spread)
+	}
+}

--- a/internal/watchmap/watchmap.go
+++ b/internal/watchmap/watchmap.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2026 The declarative-conversion-operator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package watchmap surfaces List failures inside EnqueueRequestsFromMapFunc
+// handlers. Those handlers cannot return errors to controller-runtime, so a
+// silent empty result looks identical to "no related objects" — this package
+// logs and increments a Prometheus counter instead.
+package watchmap
+
+import (
+	"context"
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	crmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+var (
+	listErrors = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "xrdconv_watch_map_list_errors_total",
+		Help: "Watch-mapping List failures that would otherwise look like an empty result (no related configs).",
+	}, []string{"map_func"})
+
+	registerOnce sync.Once
+)
+
+// ErrorHook is invoked from ListError when set. Tests use it to assert that
+// a mapping function surfaced a List failure instead of returning silently.
+var ErrorHook func(mapFunc string, err error)
+
+func ensureRegistered() {
+	registerOnce.Do(func() {
+		crmetrics.Registry.MustRegister(listErrors)
+	})
+}
+
+// ListError logs err, increments xrdconv_watch_map_list_errors_total for
+// mapFunc, invokes ErrorHook if set, and returns an empty request slice.
+// Call this instead of a bare `return nil` when a watch-mapping List fails.
+func ListError(ctx context.Context, mapFunc string, err error) []reconcile.Request {
+	ensureRegistered()
+	log.FromContext(ctx).Error(err, "watch mapping list failed; related reconciles may be skipped until the next event or periodic resync", "mapFunc", mapFunc)
+	listErrors.WithLabelValues(mapFunc).Inc()
+	if ErrorHook != nil {
+		ErrorHook(mapFunc, err)
+	}
+	return nil
+}

--- a/internal/webhook/crdconversionconfig_webhook.go
+++ b/internal/webhook/crdconversionconfig_webhook.go
@@ -100,17 +100,5 @@ func (v *CRDConversionConfigValidator) validate(ctx context.Context, cfg *terask
 }
 
 func (v *CRDConversionConfigValidator) validateUniqueTarget(ctx context.Context, cfg *teraskyv1alpha1.CRDConversionConfig) error {
-	var list teraskyv1alpha1.CRDConversionConfigList
-	if err := v.Client.List(ctx, &list); err != nil {
-		return fmt.Errorf("listing existing CRDConversionConfigs: %w", err)
-	}
-	for _, other := range list.Items {
-		if other.Name == cfg.Name {
-			continue
-		}
-		if other.Spec.TargetCRD.Name == cfg.Spec.TargetCRD.Name {
-			return fmt.Errorf("CRDConversionConfig %q already targets CRD %q; only one config per CRD is supported", other.Name, cfg.Spec.TargetCRD.Name)
-		}
-	}
-	return nil
+	return validateRegistryKeyAvailable(ctx, v.Client, cfg.Spec.TargetCRD.Name, cfg.Name, "crd")
 }

--- a/internal/webhook/registry_key.go
+++ b/internal/webhook/registry_key.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2026 The declarative-conversion-operator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"context"
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	teraskyv1alpha1 "github.com/terasky-oss/declarative-conversion-operator/api/v1alpha1"
+)
+
+// validateRegistryKeyAvailable rejects a config whose target resource name
+// would collide with another config in the webhook-server registry.
+//
+// Registry keys are the bare target name (XRD or CRD), shared across both
+// config kinds. Same-kind duplicates are rejected here as well as
+// cross-kind collisions (e.g. an XRDConversionConfig and a
+// CRDConversionConfig both targeting "xfoos.example.org").
+//
+// skipName/skipKind identify the object being validated so updates of an
+// existing config do not collide with themselves. kind must be "xrd" or "crd".
+func validateRegistryKeyAvailable(ctx context.Context, c client.Client, targetName, skipName, skipKind string) error {
+	if targetName == "" {
+		return nil
+	}
+
+	var xrds teraskyv1alpha1.XRDConversionConfigList
+	if err := c.List(ctx, &xrds); err != nil {
+		return fmt.Errorf("listing existing XRDConversionConfigs: %w", err)
+	}
+	for _, other := range xrds.Items {
+		if skipKind == "xrd" && other.Name == skipName {
+			continue
+		}
+		if other.Spec.TargetXRD.Name == targetName {
+			return fmt.Errorf("XRDConversionConfig %q already targets %q; registry keys are the bare target name shared by XRD and CRD configs, so only one config per target name is supported", other.Name, targetName)
+		}
+	}
+
+	var crds teraskyv1alpha1.CRDConversionConfigList
+	if err := c.List(ctx, &crds); err != nil {
+		return fmt.Errorf("listing existing CRDConversionConfigs: %w", err)
+	}
+	for _, other := range crds.Items {
+		if skipKind == "crd" && other.Name == skipName {
+			continue
+		}
+		if other.Spec.TargetCRD.Name == targetName {
+			return fmt.Errorf("CRDConversionConfig %q already targets %q; registry keys are the bare target name shared by XRD and CRD configs, so only one config per target name is supported", other.Name, targetName)
+		}
+	}
+	return nil
+}

--- a/internal/webhook/registry_key_test.go
+++ b/internal/webhook/registry_key_test.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2026 The declarative-conversion-operator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestValidateRegistryKey_XRDVsCRD_Rejected(t *testing.T) {
+	existingXRD := renameRuleXRDConfig("xrd-cfg", "shared.example.org")
+	c := newFakeClient(existingXRD).Build()
+
+	v := &CRDConversionConfigValidator{Client: c, Enabled: true}
+	cfg := renameRuleCRDConfig("crd-cfg", "shared.example.org")
+	_, err := v.ValidateCreate(context.Background(), cfg)
+	if err == nil {
+		t.Fatalf("expected cross-kind registry key collision to be rejected")
+	}
+	if !strings.Contains(err.Error(), "XRDConversionConfig \"xrd-cfg\"") {
+		t.Fatalf("expected error to name the colliding XRD config, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "shared.example.org") {
+		t.Fatalf("expected error to name the colliding target, got: %v", err)
+	}
+}
+
+func TestValidateRegistryKey_CRDVsXRD_Rejected(t *testing.T) {
+	existingCRD := renameRuleCRDConfig("crd-cfg", "shared.example.org")
+	c := newFakeClient(existingCRD).Build()
+
+	v := &XRDConversionConfigValidator{Client: c, Enabled: true}
+	cfg := renameRuleXRDConfig("xrd-cfg", "shared.example.org")
+	_, err := v.ValidateCreate(context.Background(), cfg)
+	if err == nil {
+		t.Fatalf("expected cross-kind registry key collision to be rejected")
+	}
+	if !strings.Contains(err.Error(), "CRDConversionConfig \"crd-cfg\"") {
+		t.Fatalf("expected error to name the colliding CRD config, got: %v", err)
+	}
+}
+
+func TestValidateRegistryKey_CRDVsCRD_Rejected(t *testing.T) {
+	existing := renameRuleCRDConfig("existing", "foos.example.org")
+	c := newFakeClient(existing).Build()
+	v := &CRDConversionConfigValidator{Client: c, Enabled: true}
+	cfg := renameRuleCRDConfig("cfg", "foos.example.org")
+	if _, err := v.ValidateCreate(context.Background(), cfg); err == nil {
+		t.Fatalf("expected same-kind CRD target collision to be rejected")
+	}
+}
+
+func TestValidateRegistryKey_UpdateSelf_Allowed(t *testing.T) {
+	existing := renameRuleXRDConfig("cfg", "xfoos.example.org")
+	xrd := establishedXRD("xfoos.example.org")
+	c := newFakeClient(existing, xrd).Build()
+	v := &XRDConversionConfigValidator{Client: c, Enabled: true}
+	if _, err := v.ValidateUpdate(context.Background(), existing, existing); err != nil {
+		t.Fatalf("updating a config must not collide with itself: %v", err)
+	}
+}

--- a/internal/webhook/xrdconversionconfig_webhook.go
+++ b/internal/webhook/xrdconversionconfig_webhook.go
@@ -277,17 +277,5 @@ func validateOneRule(r teraskyv1alpha1.ConversionRule, depth int) error {
 }
 
 func (v *XRDConversionConfigValidator) validateUniqueTarget(ctx context.Context, cfg *teraskyv1alpha1.XRDConversionConfig) error {
-	var list teraskyv1alpha1.XRDConversionConfigList
-	if err := v.Client.List(ctx, &list); err != nil {
-		return fmt.Errorf("listing existing XRDConversionConfigs: %w", err)
-	}
-	for _, other := range list.Items {
-		if other.Name == cfg.Name {
-			continue
-		}
-		if other.Spec.TargetXRD.Name == cfg.Spec.TargetXRD.Name {
-			return fmt.Errorf("XRDConversionConfig %q already targets XRD %q; only one config per XRD is supported", other.Name, cfg.Spec.TargetXRD.Name)
-		}
-	}
-	return nil
+	return validateRegistryKeyAvailable(ctx, v.Client, cfg.Spec.TargetXRD.Name, cfg.Name, "xrd")
 }

--- a/internal/webhookserver/metrics.go
+++ b/internal/webhookserver/metrics.go
@@ -29,6 +29,7 @@ type Metrics struct {
 	ObjectsTotal        *prometheus.CounterVec
 	LossyTotal          *prometheus.CounterVec
 	RegistrySize        prometheus.Gauge
+	RegistryEntryLoaded *prometheus.GaugeVec
 	RegistryLastReload  *prometheus.GaugeVec
 	RegistryReloadTotal *prometheus.CounterVec
 	RegistryCompileErr  *prometheus.CounterVec
@@ -57,15 +58,19 @@ func NewMetrics(reg prometheus.Registerer) *Metrics {
 		}, []string{"xrd", "direction"}),
 		RegistrySize: prometheus.NewGauge(prometheus.GaugeOpts{
 			Name: "xrdconv_webhook_registry_size",
-			Help: "Number of XRD paths currently loaded on this replica.",
+			Help: "Number of target resources (XRD/CRD names) currently present in this replica's registry, including error-only placeholders.",
 		}),
+		RegistryEntryLoaded: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "xrdconv_webhook_registry_entry_loaded",
+			Help: "1 if this replica has a compiled, servable conversion plan for the target (label xrd); 0 if the registry entry is error-only / not ready. Scraped per pod, so replica identity comes from the scrape target.",
+		}, []string{"xrd"}),
 		RegistryLastReload: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "xrdconv_webhook_registry_last_reload_timestamp_seconds",
-			Help: "Unix timestamp of the last successful compile, per XRD.",
+			Help: "Unix timestamp of the last successful compile, per target.",
 		}, []string{"xrd"}),
 		RegistryReloadTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "xrdconv_webhook_registry_reload_total",
-			Help: "Total attempted (re)compiles, per XRD and result.",
+			Help: "Total attempted (re)compiles, per target and result.",
 		}, []string{"xrd", "result"}),
 		RegistryCompileErr: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "xrdconv_webhook_registry_compile_errors_total",
@@ -76,6 +81,26 @@ func NewMetrics(reg prometheus.Registerer) *Metrics {
 			Help: "1 if this replica's registry has completed its initial sync and is serving traffic.",
 		}),
 	}
-	reg.MustRegister(m.ReviewDuration, m.ReviewRequestsTotal, m.ObjectsTotal, m.LossyTotal, m.RegistrySize, m.RegistryLastReload, m.RegistryReloadTotal, m.RegistryCompileErr, m.Ready)
+	reg.MustRegister(m.ReviewDuration, m.ReviewRequestsTotal, m.ObjectsTotal, m.LossyTotal, m.RegistrySize, m.RegistryEntryLoaded, m.RegistryLastReload, m.RegistryReloadTotal, m.RegistryCompileErr, m.Ready)
 	return m
+}
+
+// SyncRegistryMetrics refreshes RegistrySize and per-target
+// RegistryEntryLoaded gauges from the live registry snapshot. Call after
+// any Set / Remove / RecordError so operators can scrape "is config X
+// loaded on this replica?" without exec'ing into the pod.
+func (m *Metrics) SyncRegistryMetrics(reg *Registry) {
+	if m == nil || reg == nil {
+		return
+	}
+	snap := reg.Snapshot()
+	m.RegistrySize.Set(float64(len(snap)))
+	m.RegistryEntryLoaded.Reset()
+	for name, entry := range snap {
+		loaded := 0.0
+		if entry != nil && entry.Router != nil {
+			loaded = 1
+		}
+		m.RegistryEntryLoaded.WithLabelValues(name).Set(loaded)
+	}
 }

--- a/internal/webhookserver/metrics_test.go
+++ b/internal/webhookserver/metrics_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2026 The declarative-conversion-operator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhookserver
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	teraskyv1alpha1 "github.com/terasky-oss/declarative-conversion-operator/api/v1alpha1"
+	"github.com/terasky-oss/declarative-conversion-operator/pkg/engine"
+)
+
+func TestSyncRegistryMetrics_ReflectsLoadedAndErrorEntries(t *testing.T) {
+	reg := NewRegistry()
+	metrics := NewMetrics(newTestRegisterer())
+
+	reg.Set("ready.example.org", &CompiledEntry{
+		Router: &engine.Router{Hub: "v2", Plans: map[string]*engine.Plan{"v1": {}}},
+	})
+	reg.RecordError("broken.example.org", "compile failed")
+	metrics.SyncRegistryMetrics(reg)
+
+	if got := testutil.ToFloat64(metrics.RegistrySize); got != 2 {
+		t.Fatalf("expected registry_size=2, got %v", got)
+	}
+	if got := testutil.ToFloat64(metrics.RegistryEntryLoaded.WithLabelValues("ready.example.org")); got != 1 {
+		t.Fatalf("expected loaded=1 for ready target, got %v", got)
+	}
+	if got := testutil.ToFloat64(metrics.RegistryEntryLoaded.WithLabelValues("broken.example.org")); got != 0 {
+		t.Fatalf("expected loaded=0 for error-only target, got %v", got)
+	}
+
+	reg.Remove("ready.example.org")
+	metrics.SyncRegistryMetrics(reg)
+	if got := testutil.ToFloat64(metrics.RegistrySize); got != 1 {
+		t.Fatalf("expected registry_size=1 after remove, got %v", got)
+	}
+}
+
+func TestReconcileOneXRD_UpdatesRegistryReadinessMetrics(t *testing.T) {
+	xrd := establishedXRD("xfoos.example.org")
+	cfg := renameRuleXRDConfig("cfg", "xfoos.example.org")
+	server := &teraskyv1alpha1.ConversionWebhookServer{}
+	server.Name = "srv"
+	server.Spec.Default = true
+
+	c := newFakeClient(xrd, cfg, server).Build()
+	metrics := NewMetrics(newTestRegisterer())
+	r := &Reconciler{
+		Client: c, ServerName: "srv", Registry: NewRegistry(),
+		EnableXRDSupport: true, Metrics: metrics,
+	}
+
+	if err := r.reconcileOneXRD(context.Background(), "cfg"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := testutil.ToFloat64(metrics.RegistrySize); got != 1 {
+		t.Fatalf("expected registry_size=1 after compile, got %v", got)
+	}
+	if got := testutil.ToFloat64(metrics.RegistryEntryLoaded.WithLabelValues("xfoos.example.org")); got != 1 {
+		t.Fatalf("expected entry_loaded=1 after compile, got %v", got)
+	}
+}

--- a/internal/webhookserver/reconciler.go
+++ b/internal/webhookserver/reconciler.go
@@ -356,7 +356,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		if err := ctrl.NewControllerManagedBy(mgr).
 			For(&teraskyv1alpha1.XRDConversionConfig{}).
 			Watches(xrdObj, handler.EnqueueRequestsFromMapFunc(r.mapXRDToConfigs)).
-			Watches(&teraskyv1alpha1.ConversionWebhookServer{}, enqueue.PacedMapFunc(r.mapServerToAssignedXRDConfigs, enqueue.CWSConfigEnqueueQPS)).
+			Watches(&teraskyv1alpha1.ConversionWebhookServer{}, enqueue.PacedMapFuncs(r.mapServerToAssignedXRDConfigs, r.mapServerTransitionToAssignedXRDConfigs, enqueue.CWSConfigEnqueueQPS)).
 			Named("webhookserver-registry-xrd").
 			Complete(reconcile.Func(r.reconcileXRD)); err != nil {
 			return fmt.Errorf("setting up XRD registry controller: %w", err)
@@ -377,7 +377,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		if err := ctrl.NewControllerManagedBy(mgr).
 			For(&teraskyv1alpha1.CRDConversionConfig{}).
 			Watches(&extv1.CustomResourceDefinition{}, handler.EnqueueRequestsFromMapFunc(r.mapCRDToConfigs)).
-			Watches(&teraskyv1alpha1.ConversionWebhookServer{}, enqueue.PacedMapFunc(r.mapServerToAssignedCRDConfigs, enqueue.CWSConfigEnqueueQPS)).
+			Watches(&teraskyv1alpha1.ConversionWebhookServer{}, enqueue.PacedMapFuncs(r.mapServerToAssignedCRDConfigs, r.mapServerTransitionToAssignedCRDConfigs, enqueue.CWSConfigEnqueueQPS)).
 			Named("webhookserver-registry-crd").
 			Complete(reconcile.Func(r.reconcileCRD)); err != nil {
 			return fmt.Errorf("setting up CRD registry controller: %w", err)
@@ -412,35 +412,129 @@ func (r *Reconciler) mapCRDToConfigs(ctx context.Context, obj client.Object) []r
 }
 
 func (r *Reconciler) mapServerToAssignedXRDConfigs(ctx context.Context, obj client.Object) []reconcile.Request {
-	var list teraskyv1alpha1.XRDConversionConfigList
-	if err := r.List(ctx, &list); err != nil {
+	reqs, err := mapAssignedXRD(ctx, r.Client, obj.GetName(), asCWS(obj))
+	if err != nil {
 		return watchmap.ListError(ctx, "webhookserver.mapServerToAssignedXRDConfigs", err)
 	}
-	var servers teraskyv1alpha1.ConversionWebhookServerList
-	if err := r.List(ctx, &servers); err != nil {
-		return watchmap.ListError(ctx, "webhookserver.mapServerToAssignedXRDConfigs", err)
-	}
-	assigned := assign.ConfigsAssignedTo(list.Items, servers.Items, obj.GetName())
-	reqs := make([]reconcile.Request, 0, len(assigned))
-	for _, cfg := range assigned {
-		reqs = append(reqs, reconcile.Request{NamespacedName: types.NamespacedName{Name: cfg.Name}})
+	return reqs
+}
+
+func (r *Reconciler) mapServerTransitionToAssignedXRDConfigs(ctx context.Context, oldObj, newObj client.Object) []reconcile.Request {
+	name := objectName(oldObj, newObj)
+	reqs, err := mapAssignedXRD(ctx, r.Client, name, asCWS(oldObj), asCWS(newObj))
+	if err != nil {
+		return watchmap.ListError(ctx, "webhookserver.mapServerTransitionToAssignedXRDConfigs", err)
 	}
 	return reqs
 }
 
 func (r *Reconciler) mapServerToAssignedCRDConfigs(ctx context.Context, obj client.Object) []reconcile.Request {
-	var list teraskyv1alpha1.CRDConversionConfigList
-	if err := r.List(ctx, &list); err != nil {
+	reqs, err := mapAssignedCRD(ctx, r.Client, obj.GetName(), asCWS(obj))
+	if err != nil {
 		return watchmap.ListError(ctx, "webhookserver.mapServerToAssignedCRDConfigs", err)
-	}
-	var servers teraskyv1alpha1.ConversionWebhookServerList
-	if err := r.List(ctx, &servers); err != nil {
-		return watchmap.ListError(ctx, "webhookserver.mapServerToAssignedCRDConfigs", err)
-	}
-	assigned := assign.ConfigsAssignedTo(list.Items, servers.Items, obj.GetName())
-	reqs := make([]reconcile.Request, 0, len(assigned))
-	for _, cfg := range assigned {
-		reqs = append(reqs, reconcile.Request{NamespacedName: types.NamespacedName{Name: cfg.Name}})
 	}
 	return reqs
+}
+
+func (r *Reconciler) mapServerTransitionToAssignedCRDConfigs(ctx context.Context, oldObj, newObj client.Object) []reconcile.Request {
+	name := objectName(oldObj, newObj)
+	reqs, err := mapAssignedCRD(ctx, r.Client, name, asCWS(oldObj), asCWS(newObj))
+	if err != nil {
+		return watchmap.ListError(ctx, "webhookserver.mapServerTransitionToAssignedCRDConfigs", err)
+	}
+	return reqs
+}
+
+func objectName(oldObj, newObj client.Object) string {
+	if newObj != nil {
+		return newObj.GetName()
+	}
+	if oldObj != nil {
+		return oldObj.GetName()
+	}
+	return ""
+}
+
+func asCWS(obj client.Object) *teraskyv1alpha1.ConversionWebhookServer {
+	if obj == nil {
+		return nil
+	}
+	s, ok := obj.(*teraskyv1alpha1.ConversionWebhookServer)
+	if !ok {
+		return nil
+	}
+	return s
+}
+
+func mapAssignedXRD(ctx context.Context, c client.Client, serverName string, views ...*teraskyv1alpha1.ConversionWebhookServer) ([]reconcile.Request, error) {
+	var list teraskyv1alpha1.XRDConversionConfigList
+	if err := c.List(ctx, &list); err != nil {
+		return nil, err
+	}
+	var servers teraskyv1alpha1.ConversionWebhookServerList
+	if err := c.List(ctx, &servers); err != nil {
+		return nil, err
+	}
+	seen := map[string]struct{}{}
+	var reqs []reconcile.Request
+	for _, view := range views {
+		if view == nil {
+			continue
+		}
+		for _, cfg := range assign.ConfigsAssignedTo(list.Items, serversWithView(servers.Items, view), serverName) {
+			if _, ok := seen[cfg.Name]; ok {
+				continue
+			}
+			seen[cfg.Name] = struct{}{}
+			reqs = append(reqs, reconcile.Request{NamespacedName: types.NamespacedName{Name: cfg.Name}})
+		}
+	}
+	return reqs, nil
+}
+
+func mapAssignedCRD(ctx context.Context, c client.Client, serverName string, views ...*teraskyv1alpha1.ConversionWebhookServer) ([]reconcile.Request, error) {
+	var list teraskyv1alpha1.CRDConversionConfigList
+	if err := c.List(ctx, &list); err != nil {
+		return nil, err
+	}
+	var servers teraskyv1alpha1.ConversionWebhookServerList
+	if err := c.List(ctx, &servers); err != nil {
+		return nil, err
+	}
+	seen := map[string]struct{}{}
+	var reqs []reconcile.Request
+	for _, view := range views {
+		if view == nil {
+			continue
+		}
+		for _, cfg := range assign.ConfigsAssignedTo(list.Items, serversWithView(servers.Items, view), serverName) {
+			if _, ok := seen[cfg.Name]; ok {
+				continue
+			}
+			seen[cfg.Name] = struct{}{}
+			reqs = append(reqs, reconcile.Request{NamespacedName: types.NamespacedName{Name: cfg.Name}})
+		}
+	}
+	return reqs, nil
+}
+
+func serversWithView(live []teraskyv1alpha1.ConversionWebhookServer, view *teraskyv1alpha1.ConversionWebhookServer) []teraskyv1alpha1.ConversionWebhookServer {
+	out := make([]teraskyv1alpha1.ConversionWebhookServer, 0, len(live)+1)
+	found := false
+	for _, s := range live {
+		if s.Name == view.Name {
+			out = append(out, *view)
+			found = true
+			continue
+		}
+		cp := s
+		if view.Spec.Default {
+			cp.Spec.Default = false
+		}
+		out = append(out, cp)
+	}
+	if !found {
+		out = append(out, *view)
+	}
+	return out
 }

--- a/internal/webhookserver/reconciler.go
+++ b/internal/webhookserver/reconciler.go
@@ -33,6 +33,7 @@ import (
 
 	teraskyv1alpha1 "github.com/terasky-oss/declarative-conversion-operator/api/v1alpha1"
 	"github.com/terasky-oss/declarative-conversion-operator/internal/assign"
+	"github.com/terasky-oss/declarative-conversion-operator/internal/enqueue"
 	"github.com/terasky-oss/declarative-conversion-operator/pkg/crdadapter"
 	"github.com/terasky-oss/declarative-conversion-operator/pkg/engine"
 	"github.com/terasky-oss/declarative-conversion-operator/pkg/xrdadapter"
@@ -354,7 +355,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		if err := ctrl.NewControllerManagedBy(mgr).
 			For(&teraskyv1alpha1.XRDConversionConfig{}).
 			Watches(xrdObj, handler.EnqueueRequestsFromMapFunc(r.mapXRDToConfigs)).
-			Watches(&teraskyv1alpha1.ConversionWebhookServer{}, handler.EnqueueRequestsFromMapFunc(r.mapAnyServerToAllXRDConfigs)).
+			Watches(&teraskyv1alpha1.ConversionWebhookServer{}, enqueue.PacedMapFunc(r.mapServerToAssignedXRDConfigs, enqueue.CWSConfigEnqueueQPS)).
 			Named("webhookserver-registry-xrd").
 			Complete(reconcile.Func(r.reconcileXRD)); err != nil {
 			return fmt.Errorf("setting up XRD registry controller: %w", err)
@@ -375,7 +376,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		if err := ctrl.NewControllerManagedBy(mgr).
 			For(&teraskyv1alpha1.CRDConversionConfig{}).
 			Watches(&extv1.CustomResourceDefinition{}, handler.EnqueueRequestsFromMapFunc(r.mapCRDToConfigs)).
-			Watches(&teraskyv1alpha1.ConversionWebhookServer{}, handler.EnqueueRequestsFromMapFunc(r.mapAnyServerToAllCRDConfigs)).
+			Watches(&teraskyv1alpha1.ConversionWebhookServer{}, enqueue.PacedMapFunc(r.mapServerToAssignedCRDConfigs, enqueue.CWSConfigEnqueueQPS)).
 			Named("webhookserver-registry-crd").
 			Complete(reconcile.Func(r.reconcileCRD)); err != nil {
 			return fmt.Errorf("setting up CRD registry controller: %w", err)
@@ -409,26 +410,36 @@ func (r *Reconciler) mapCRDToConfigs(ctx context.Context, obj client.Object) []r
 	return reqs
 }
 
-func (r *Reconciler) mapAnyServerToAllXRDConfigs(ctx context.Context, _ client.Object) []reconcile.Request {
+func (r *Reconciler) mapServerToAssignedXRDConfigs(ctx context.Context, obj client.Object) []reconcile.Request {
 	var list teraskyv1alpha1.XRDConversionConfigList
 	if err := r.List(ctx, &list); err != nil {
 		return nil
 	}
-	reqs := make([]reconcile.Request, 0, len(list.Items))
-	for _, c := range list.Items {
-		reqs = append(reqs, reconcile.Request{NamespacedName: types.NamespacedName{Name: c.Name}})
+	var servers teraskyv1alpha1.ConversionWebhookServerList
+	if err := r.List(ctx, &servers); err != nil {
+		return nil
+	}
+	assigned := assign.ConfigsAssignedTo(list.Items, servers.Items, obj.GetName())
+	reqs := make([]reconcile.Request, 0, len(assigned))
+	for _, cfg := range assigned {
+		reqs = append(reqs, reconcile.Request{NamespacedName: types.NamespacedName{Name: cfg.Name}})
 	}
 	return reqs
 }
 
-func (r *Reconciler) mapAnyServerToAllCRDConfigs(ctx context.Context, _ client.Object) []reconcile.Request {
+func (r *Reconciler) mapServerToAssignedCRDConfigs(ctx context.Context, obj client.Object) []reconcile.Request {
 	var list teraskyv1alpha1.CRDConversionConfigList
 	if err := r.List(ctx, &list); err != nil {
 		return nil
 	}
-	reqs := make([]reconcile.Request, 0, len(list.Items))
-	for _, c := range list.Items {
-		reqs = append(reqs, reconcile.Request{NamespacedName: types.NamespacedName{Name: c.Name}})
+	var servers teraskyv1alpha1.ConversionWebhookServerList
+	if err := r.List(ctx, &servers); err != nil {
+		return nil
+	}
+	assigned := assign.ConfigsAssignedTo(list.Items, servers.Items, obj.GetName())
+	reqs := make([]reconcile.Request, 0, len(assigned))
+	for _, cfg := range assigned {
+		reqs = append(reqs, reconcile.Request{NamespacedName: types.NamespacedName{Name: cfg.Name}})
 	}
 	return reqs
 }

--- a/internal/webhookserver/reconciler.go
+++ b/internal/webhookserver/reconciler.go
@@ -34,6 +34,7 @@ import (
 	teraskyv1alpha1 "github.com/terasky-oss/declarative-conversion-operator/api/v1alpha1"
 	"github.com/terasky-oss/declarative-conversion-operator/internal/assign"
 	"github.com/terasky-oss/declarative-conversion-operator/internal/enqueue"
+	"github.com/terasky-oss/declarative-conversion-operator/internal/watchmap"
 	"github.com/terasky-oss/declarative-conversion-operator/pkg/crdadapter"
 	"github.com/terasky-oss/declarative-conversion-operator/pkg/engine"
 	"github.com/terasky-oss/declarative-conversion-operator/pkg/xrdadapter"
@@ -389,7 +390,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 func (r *Reconciler) mapXRDToConfigs(ctx context.Context, obj client.Object) []reconcile.Request {
 	var list teraskyv1alpha1.XRDConversionConfigList
 	if err := r.List(ctx, &list, client.MatchingFields{TargetXRDNameIndex: obj.GetName()}); err != nil {
-		return nil
+		return watchmap.ListError(ctx, "webhookserver.mapXRDToConfigs", err)
 	}
 	reqs := make([]reconcile.Request, 0, len(list.Items))
 	for _, c := range list.Items {
@@ -401,7 +402,7 @@ func (r *Reconciler) mapXRDToConfigs(ctx context.Context, obj client.Object) []r
 func (r *Reconciler) mapCRDToConfigs(ctx context.Context, obj client.Object) []reconcile.Request {
 	var list teraskyv1alpha1.CRDConversionConfigList
 	if err := r.List(ctx, &list, client.MatchingFields{TargetCRDNameIndex: obj.GetName()}); err != nil {
-		return nil
+		return watchmap.ListError(ctx, "webhookserver.mapCRDToConfigs", err)
 	}
 	reqs := make([]reconcile.Request, 0, len(list.Items))
 	for _, c := range list.Items {
@@ -413,11 +414,11 @@ func (r *Reconciler) mapCRDToConfigs(ctx context.Context, obj client.Object) []r
 func (r *Reconciler) mapServerToAssignedXRDConfigs(ctx context.Context, obj client.Object) []reconcile.Request {
 	var list teraskyv1alpha1.XRDConversionConfigList
 	if err := r.List(ctx, &list); err != nil {
-		return nil
+		return watchmap.ListError(ctx, "webhookserver.mapServerToAssignedXRDConfigs", err)
 	}
 	var servers teraskyv1alpha1.ConversionWebhookServerList
 	if err := r.List(ctx, &servers); err != nil {
-		return nil
+		return watchmap.ListError(ctx, "webhookserver.mapServerToAssignedXRDConfigs", err)
 	}
 	assigned := assign.ConfigsAssignedTo(list.Items, servers.Items, obj.GetName())
 	reqs := make([]reconcile.Request, 0, len(assigned))
@@ -430,11 +431,11 @@ func (r *Reconciler) mapServerToAssignedXRDConfigs(ctx context.Context, obj clie
 func (r *Reconciler) mapServerToAssignedCRDConfigs(ctx context.Context, obj client.Object) []reconcile.Request {
 	var list teraskyv1alpha1.CRDConversionConfigList
 	if err := r.List(ctx, &list); err != nil {
-		return nil
+		return watchmap.ListError(ctx, "webhookserver.mapServerToAssignedCRDConfigs", err)
 	}
 	var servers teraskyv1alpha1.ConversionWebhookServerList
 	if err := r.List(ctx, &servers); err != nil {
-		return nil
+		return watchmap.ListError(ctx, "webhookserver.mapServerToAssignedCRDConfigs", err)
 	}
 	assigned := assign.ConfigsAssignedTo(list.Items, servers.Items, obj.GetName())
 	reqs := make([]reconcile.Request, 0, len(assigned))

--- a/internal/webhookserver/reconciler.go
+++ b/internal/webhookserver/reconciler.go
@@ -68,11 +68,9 @@ const (
 // controller-runtime's normal backoff-and-retry applies.
 //
 // Note: registry keys are the bare target-resource name, shared between
-// the XRD and CRD paths. A CRDConversionConfig deliberately targeting the
-// native CustomResourceDefinition Crossplane generates for some XRD's
-// composite type (same name, by construction) would collide with that
-// XRD's own registry entry — an already-redundant, self-inflicted
-// configuration this package doesn't attempt to detect or prevent.
+// the XRD and CRD paths. Cross-kind collisions (an XRDConversionConfig and
+// a CRDConversionConfig targeting the same name) are rejected at admission
+// by internal/webhook.validateRegistryKeyAvailable.
 type Reconciler struct {
 	client.Client
 	ServerName string

--- a/internal/webhookserver/reconciler.go
+++ b/internal/webhookserver/reconciler.go
@@ -154,6 +154,9 @@ func (r *Reconciler) reconcileOneXRD(ctx context.Context, name string) error {
 	assigned, err := assign.ResolveAssignment(&cfg, servers.Items)
 	if err != nil || assigned != r.ServerName {
 		r.Registry.Remove(cfg.Spec.TargetXRD.Name)
+		if r.Metrics != nil {
+			r.Metrics.SyncRegistryMetrics(r.Registry)
+		}
 		return nil
 	}
 
@@ -213,6 +216,9 @@ func (r *Reconciler) reconcileOneCRD(ctx context.Context, name string) error {
 	assigned, err := assign.ResolveAssignment(&cfg, servers.Items)
 	if err != nil || assigned != r.ServerName {
 		r.Registry.Remove(cfg.Spec.TargetCRD.Name)
+		if r.Metrics != nil {
+			r.Metrics.SyncRegistryMetrics(r.Registry)
+		}
 		return nil
 	}
 
@@ -269,6 +275,7 @@ func (r *Reconciler) compileAndRegister(targetName, hubVersion string, reviewVer
 	if r.Metrics != nil {
 		r.Metrics.RegistryReloadTotal.WithLabelValues(targetName, "success").Inc()
 		r.Metrics.RegistryLastReload.WithLabelValues(targetName).Set(float64(time.Now().Unix()))
+		r.Metrics.SyncRegistryMetrics(r.Registry)
 	}
 }
 
@@ -285,6 +292,9 @@ func (r *Reconciler) forgetConfig(key string) {
 	r.mu.Unlock()
 	if ok {
 		r.Registry.Remove(targetName)
+		if r.Metrics != nil {
+			r.Metrics.SyncRegistryMetrics(r.Registry)
+		}
 	}
 }
 
@@ -293,6 +303,7 @@ func (r *Reconciler) recordFailure(targetName, reason, msg string) {
 	if r.Metrics != nil {
 		r.Metrics.RegistryReloadTotal.WithLabelValues(targetName, "error").Inc()
 		r.Metrics.RegistryCompileErr.WithLabelValues(targetName, reason).Inc()
+		r.Metrics.SyncRegistryMetrics(r.Registry)
 	}
 }
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,6 +76,7 @@ nav:
       - CRDConversionConfig: configuration/crdconversionconfig.md
       - ConversionWebhookServer: configuration/conversionwebhookserver.md
   - Architecture: architecture.md
+  - Observability: observability.md
   - CLI Reference: cli.md
   - Strategy Reference:
       - strategies/index.md


### PR DESCRIPTION
## Summary
Implements Epic Phase 2 — degraded states (schema drift, partial failures, config collisions, load spikes) are safe, visible, and recoverable.

- **2.1** FailClosed / KeepServingStale failure-path integration tests (crash before/after patch, mid-lifecycle schema drift, partway revert recovery) for XRD and CRD controllers
- **2.2** Registry readiness metrics (`registry_size`, per-target `registry_entry_loaded`) + `docs/observability.md`
- **2.3** Admission rejection of XRD/CRD registry key collisions (cross-kind and same-kind)
- **2.4** CWS-change fan-out filtered to assigned configs and paced at 50 QPS
- **2.5** Watch-mapping List failures logged + counted (`xrdconv_watch_map_list_errors_total`) instead of silent empty results
- **2.6** Precise config-delete race-window documentation; finalizer model concluded sufficient

Closes #22
Closes #23
Closes #24
Closes #25
Closes #26
Closes #27
Closes #28

## Test plan
- [x] `make test` (unit tests with race detector)
- [ ] CI unit / lint / docs workflows green
- [ ] AI code review feedback triaged
- [ ] Optional: `make test-e2e` / `test-e2e-crd-only` if kind available

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Prevents duplicate target names across XRD and CRD conversion configurations.
  - Adds registry readiness and per-target loading metrics.
  - Adds observability guidance, PromQL examples, recovery indicators, and debugging references.
  - Documents configuration deletion race handling and safety behavior.

- **Bug Fixes**
  - Improves recovery after interrupted reconciliation and schema drift.
  - Safely reverts fail-closed conversions, including partial-failure recovery.
  - Limits reconciliation to affected assignments with paced processing.
  - Surfaces watch-mapping list failures through logs and metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->