### PR TITLE
Phase 4: CLI and authoring UX

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -9,6 +9,7 @@ convctl test      --config config.yaml (--xrd xrd.yaml | --crd crd.yaml) (--samp
 convctl diff      --config a.yaml --config b.yaml (--xrd xrd.yaml | --crd crd.yaml) [-o json|table]
 convctl diff      --config config.yaml --live [-o json|table]
 convctl convert   --config config.yaml (--xrd xrd.yaml | --crd crd.yaml) --sample obj.yaml --to v2 [-o yaml|json]
+convctl suggest   --config config.yaml (--xrd xrd.yaml | --crd crd.yaml) [-o yaml|json]
 ```
 
 ## `convctl validate`
@@ -151,6 +152,48 @@ metadata:
 spec:
   storageGB: "100"
 ```
+
+## `convctl suggest`
+
+Proposes rule stubs for the fields a config leaves uncovered — the tedious half of authoring a mapping between two versions. Point it at a config with no rules at all and it bootstraps a first draft; point it at a half-finished one and it fills in what's still missing.
+
+```console
+convctl suggest --xrd xrd.yaml --config xrdconversionconfig.yaml
+convctl suggest --crd crd.yaml --config crdconversionconfig.yaml -o json
+```
+
+| Flag | Description |
+|---|---|
+| `-c, --config` | Path to an `XRDConversionConfig` or `CRDConversionConfig` YAML file. **Required.** |
+| `-x, --xrd` | Path to an XRD YAML file. Required for an `XRDConversionConfig`; mutually exclusive with `--crd`. |
+| `--crd` | Path to a CRD YAML file. Required for a `CRDConversionConfig`. |
+| `-o, --output` | `yaml` (default) or `json`. |
+
+Two kinds of suggestion are made, per spoke:
+
+- **`FieldRename`**, when an uncovered hub field and an uncovered spoke field sit under the same parent path, declare the same type, and have similar enough names after normalizing away casing and punctuation (`storageGB` ↔ `storage_size`).
+- **`TypeCoerce`**, when a field keeps its exact path but changes scalar type between the two versions.
+
+Nothing else is guessed at. A `ScalarToFields` split or an `ArrayToMapByKey` restructure is a design decision, not a pattern to infer from two schemas.
+
+```console
+$ convctl suggest --xrd xrd.yaml --config config-with-no-rules.yaml
+# suggested rules — review every one before merging into spec.spokes
+spokes:
+- rules:
+  - strategy: TypeCoerce
+    typeCoerce:
+      path: spec.priority
+  - fieldRename:
+      hubPath: spec.storageGB
+      spokePath: spec.storageSize
+    strategy: FieldRename
+  version: v2
+```
+
+The output is shaped exactly like a config's `spec.spokes` stanza, so accepted suggestions paste straight in.
+
+**These are heuristics, not conclusions.** Nothing can prove two differently-named fields were meant to be the same one, and name similarity will occasionally pair the wrong two. Read every suggestion, delete the wrong ones, and let `convctl validate` and `convctl test` grade what's left — a suggestion that survives both is a rule you can trust, and one that doesn't cost you a deleted line.
 
 ## Pre-upgrade checks: testing against everything that already exists
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -89,6 +89,22 @@ convctl test --xrd xrd.yaml --config xrdconversionconfig.yaml --samples ./sample
 | `1` | An unacknowledged loss or failure was found, at or above the `--fail-on` threshold. |
 | `2` | A tool/usage error (bad flags, file not found, etc.) — deliberately distinct from a test-result failure, so CI can tell "the tool broke" from "the config is bad." |
 
+`--fail-on` takes exactly `none`, `warn`, or `loss`; anything else is a usage error (`2`) rather than a silently-ignored typo that would let a broken gate report success forever.
+
+Here is every threshold against every outcome:
+
+| Run outcome | `--fail-on none` | `--fail-on warn` | `--fail-on loss` (default) |
+|---|---|---|---|
+| Everything passed | `0` | `0` | `0` |
+| Acknowledged loss only | `0` | `0` | `0` |
+| Unacknowledged loss | `0` | `1` | `1` |
+| Conversion error | `0` | `1` | `1` |
+| A declared rule no sample exercised | `0` | `1` | `0` |
+
+**Acknowledged loss alone never fails, at any threshold.** `acknowledgeLossy: true` is the config author stating on the record that a field is expected to be dropped or rounded; re-litigating that decision on every CI run would just train people to pass `--fail-on none`. What the default threshold catches is loss that *nobody* declared.
+
+`--strict` escalates coverage gaps exactly the way `--fail-on warn` does — a declared rule that no sample exercised becomes a failure. So `--fail-on loss --strict` behaves identically to `--fail-on warn`, and `--strict` changes nothing when `--fail-on warn` is already set. `--fail-on none` overrides `--strict` entirely: it is the explicit "report, never gate" switch, and always exits `0`.
+
 ## `convctl diff`
 
 Analyzes two conversion configs against the same schema and reports what changed between them — the review question "what does this config edit actually do?", answered in terms of coverage and lossiness rather than YAML lines.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -69,8 +69,18 @@ convctl test --crd crd.yaml --config crdconversionconfig.yaml --samples ./sample
 | `--fail-on` | Exit-code threshold: `none`, `warn`, or `loss` (default). |
 | `--version-pair` | Restrict testing to specific version(s). Repeatable. |
 | `--skip-identity` | Skip trivial same-version passthrough checks. |
+| `--concurrency` | How many samples to test in parallel. Defaults to one worker per available CPU. |
+| `--quiet` | Suppress the progress line written to stderr. |
 
 Each sample's asserted starting version is inferred from its own `apiVersion` — no separate index file needed.
+
+### Parallelism and progress
+
+Samples are tested in parallel, one worker per available CPU by default. This matters most for `--live`, where the sample set is every object of the target type in the cluster rather than a handful of fixtures. Set `--concurrency N` to pin the worker count (`--concurrency 1` to go fully sequential).
+
+Parallelism never changes the result. Every sample is independent, and results are collected by sample index rather than by completion order, so the report — including the order samples appear in — is byte-for-byte what a single worker would have produced. The paths *within* one sample stay sequential.
+
+While more than one sample is in flight, a `tested N/M samples` progress line is rewritten on stderr, leaving stdout clean for `--output json`/`junit` pipes. Pass `--quiet` to suppress it.
 
 ### Output formats
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -8,6 +8,7 @@ convctl analyze   --config config.yaml (--xrd xrd.yaml | --crd crd.yaml) [-o tab
 convctl test      --config config.yaml (--xrd xrd.yaml | --crd crd.yaml) (--samples ./samples/ | --live) [flags]
 convctl diff      --config a.yaml --config b.yaml (--xrd xrd.yaml | --crd crd.yaml) [-o json|table]
 convctl diff      --config config.yaml --live [-o json|table]
+convctl convert   --config config.yaml (--xrd xrd.yaml | --crd crd.yaml) --sample obj.yaml --to v2 [-o yaml|json]
 ```
 
 ## `convctl validate`
@@ -119,6 +120,37 @@ Plus, at the top level, a hub-version change and any spoke version added or remo
 With `--live`, the cluster is always the *from* side and the local file is the *to* side, so the diff reads as "what applying this file would change". If the cluster has no config of that name yet, the from side becomes an empty rule set over the same spoke versions — every rule in your file shows up as an addition, which is a far more useful answer than refusing to run.
 
 Exit codes are `0` when the two sides are equivalent, `1` when any delta is found, and `2` for usage or load errors — so `convctl diff` drops straight into a CI gate that fails a PR whose config change wasn't intended.
+
+## `convctl convert`
+
+Converts a single object and prints the result. Where `convctl test` round-trips fixtures and grades them, `convert` is the "just show me the output" tool — for eyeballing what a rule actually produces, or for piping a converted object straight into `kubectl apply`.
+
+```console
+convctl convert --xrd xrd.yaml --config xrdconversionconfig.yaml --sample widget-v1.yaml --to v3
+convctl convert --crd crd.yaml --config crdconversionconfig.yaml --sample widget.yaml --to v2 -o json
+```
+
+| Flag | Description |
+|---|---|
+| `-c, --config` | Path to an `XRDConversionConfig` or `CRDConversionConfig` YAML file. **Required.** |
+| `-x, --xrd` | Path to an XRD YAML file. Required for an `XRDConversionConfig`; mutually exclusive with `--crd`. |
+| `--crd` | Path to a CRD YAML file. Required for a `CRDConversionConfig`. |
+| `--sample` | Path to a single-document YAML file holding the object to convert. **Required.** A multi-document file is an error, not a silent "convert the first one". |
+| `--to` | Version to convert into. **Required.** |
+| `--from` | Source version. Defaults to the version in the sample's own `apiVersion`. |
+| `-o, --output` | `yaml` (default) or `json`. |
+
+The output object's `apiVersion` is rewritten to `<group>/<to>`, with the group taken from the XRD's or CRD's `spec.group` — the engine itself only ever knows version *names*, so the schema is the only thing that can supply the group. Spoke-to-spoke conversions route through the hub exactly as they do in production, and a config that doesn't validate against the schema is refused before any conversion runs.
+
+```console
+$ convctl convert --xrd xrd.yaml --config config.yaml --sample sample1-v1.yaml --to v2
+apiVersion: example.org/v2
+kind: Foo
+metadata:
+  name: sample1
+spec:
+  storageGB: "100"
+```
 
 ## Pre-upgrade checks: testing against everything that already exists
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -3,14 +3,17 @@
 `convctl` runs the exact same `pkg/engine` code the operator and webhook server use, entirely offline against local YAML files — so you can validate and test a conversion mapping before it ever touches a cluster. Every command works identically against an `XRDConversionConfig` (pass `--xrd`) or a `CRDConversionConfig` (pass `--crd`) — which one applies is determined by the config file's own `kind`, not by which flag you happen to type, so passing the wrong one is a clear error rather than a silent mismatch.
 
 ```console
-convctl validate --config config.yaml [--xrd xrd.yaml | --crd crd.yaml] [-o table|json]
-convctl analyze   --config config.yaml (--xrd xrd.yaml | --crd crd.yaml) [-o table|json]
-convctl test      --config config.yaml (--xrd xrd.yaml | --crd crd.yaml) (--samples ./samples/ | --live) [flags]
-convctl diff      --config a.yaml --config b.yaml (--xrd xrd.yaml | --crd crd.yaml) [-o json|table]
-convctl diff      --config config.yaml --live [-o json|table]
-convctl convert   --config config.yaml (--xrd xrd.yaml | --crd crd.yaml) --sample obj.yaml --to v2 [-o yaml|json]
-convctl suggest   --config config.yaml (--xrd xrd.yaml | --crd crd.yaml) [-o yaml|json]
+convctl validate      --config config.yaml [--xrd xrd.yaml | --crd crd.yaml] [-o table|json]
+convctl analyze       --config config.yaml (--xrd xrd.yaml | --crd crd.yaml) [-o table|json]
+convctl test          --config config.yaml (--xrd xrd.yaml | --crd crd.yaml) (--samples ./samples/ | --live) [flags]
+convctl diff          --config a.yaml --config b.yaml (--xrd xrd.yaml | --crd crd.yaml) [-o json|table]
+convctl diff          --config config.yaml --live [-o json|table]
+convctl convert       --config config.yaml (--xrd xrd.yaml | --crd crd.yaml) --sample obj.yaml --to v2 [-o yaml|json]
+convctl suggest       --config config.yaml (--xrd xrd.yaml | --crd crd.yaml) [-o yaml|json]
+convctl patch-preview --config config.yaml --service-name NAME --service-namespace NS --ca-bundle B64 [flags]
 ```
+
+Roughly in the order you reach for them while authoring a mapping: `suggest` drafts rules for fields nothing covers yet, `validate` and `analyze` check the config statically, `convert` shows what a single object turns into, `test` grades fixtures or every live object, `diff` reports what a config edit changed, and `patch-preview` shows the exact patch the operator will apply once you commit.
 
 ## `convctl validate`
 
@@ -220,6 +223,54 @@ spokes:
 The output is shaped exactly like a config's `spec.spokes` stanza, so accepted suggestions paste straight in.
 
 **These are heuristics, not conclusions.** Nothing can prove two differently-named fields were meant to be the same one, and name similarity will occasionally pair the wrong two. Read every suggestion, delete the wrong ones, and let `convctl validate` and `convctl test` grade what's left — a suggestion that survives both is a rule you can trust, and one that doesn't cost you a deleted line.
+
+## `convctl patch-preview`
+
+Prints the exact server-side-apply object the operator would send to the target XRD or CRD to point its `spec.conversion` at a webhook server. Useful for reviewing a change before granting the operator write access to a production XRD, and for understanding what "the operator patches your XRD" actually means in concrete YAML.
+
+```console
+convctl patch-preview --config xrdconversionconfig.yaml --xrd xrd.yaml \
+  --service-name prod-webhook-server --service-namespace conversion-system \
+  --ca-bundle "$(kubectl get secret prod-webhook-server-tls -n conversion-system -o jsonpath='{.data.ca\.crt}')"
+```
+
+| Flag | Description |
+|---|---|
+| `-c, --config` | Path to an `XRDConversionConfig` or `CRDConversionConfig` YAML file. **Required.** Supplies the target name, the config name for the `managed-by` annotation, and `conversionReviewVersions`. |
+| `--service-name` | Name of the webhook server `Service`. **Required.** |
+| `--service-namespace` | Namespace of the webhook server `Service`. **Required.** |
+| `--ca-bundle` | CA bundle, either base64-encoded (as it appears in a CRD's YAML) or raw PEM, which is detected and encoded for you. **Required.** |
+| `--path` | Webhook path. Defaults to `/convert/<target name>`, which is what the operator derives. |
+| `--port` | Webhook `Service` port. Defaults to `443`. |
+| `--plan-hash` | Value for the `conversion.terasky.com/plan-hash` annotation. Defaults to empty, which is what it is before the config's first successful validation. |
+| `-x, --xrd` / `--crd` | Optional. Supplying the schema validates the config against it first, so a config the operator would refuse to apply doesn't get a preview of being applied. |
+
+```console
+apiVersion: apiextensions.crossplane.io/v2
+kind: CompositeResourceDefinition
+metadata:
+  annotations:
+    conversion.terasky.com/managed-by: xfoos-conversion
+    conversion.terasky.com/plan-hash: sha256:abc
+  name: xfoos.example.org
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: UEVN
+        service:
+          name: prod-webhook-server
+          namespace: conversion-system
+          path: /convert/xfoos.example.org
+          port: 443
+      conversionReviewVersions:
+      - v1
+```
+
+The patch is built by `internal/conversionpatch`, the same package the controllers call — so what you see here cannot drift from what the operator applies. That is also why the service coordinates and CA bundle are flags rather than cluster lookups: `patch-preview` never constructs a Kubernetes client at all, so it cannot touch a cluster even by accident.
+
+Note that this is the *patch*, not the resulting object. It is applied with `ForceOwnership` under the `declarative-conversion-operator` field manager, so it claims exactly the fields shown and leaves every other field on the XRD or CRD to whoever owns it.
 
 ## Pre-upgrade checks: testing against everything that already exists
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -6,6 +6,8 @@
 convctl validate --config config.yaml [--xrd xrd.yaml | --crd crd.yaml] [-o table|json]
 convctl analyze   --config config.yaml (--xrd xrd.yaml | --crd crd.yaml) [-o table|json]
 convctl test      --config config.yaml (--xrd xrd.yaml | --crd crd.yaml) (--samples ./samples/ | --live) [flags]
+convctl diff      --config a.yaml --config b.yaml (--xrd xrd.yaml | --crd crd.yaml) [-o json|table]
+convctl diff      --config config.yaml --live [-o json|table]
 ```
 
 ## `convctl validate`
@@ -84,6 +86,39 @@ convctl test --xrd xrd.yaml --config xrdconversionconfig.yaml --samples ./sample
 | `0` | Every conversion path passed, or any loss found was already acknowledged (`acknowledgeLossy: true`). |
 | `1` | An unacknowledged loss or failure was found, at or above the `--fail-on` threshold. |
 | `2` | A tool/usage error (bad flags, file not found, etc.) — deliberately distinct from a test-result failure, so CI can tell "the tool broke" from "the config is bad." |
+
+## `convctl diff`
+
+Analyzes two conversion configs against the same schema and reports what changed between them — the review question "what does this config edit actually do?", answered in terms of coverage and lossiness rather than YAML lines.
+
+```console
+convctl diff --xrd xrd.yaml --config current.yaml --config proposed.yaml
+convctl diff --crd crd.yaml --config current.yaml --config proposed.yaml -o table
+convctl diff --config proposed.yaml --live
+```
+
+| Flag | Description |
+|---|---|
+| `-c, --config` | Path to a conversion config YAML file. **Required.** Pass it exactly twice to compare two files, or exactly once together with `--live`. Both files must be the same kind. |
+| `-x, --xrd` | Path to an XRD YAML file. Required in two-file mode for `XRDConversionConfig`s; mutually exclusive with `--crd`. Ignored with `--live`, which reads the schema from the cluster. |
+| `--crd` | Path to a CRD YAML file. Required in two-file mode for `CRDConversionConfig`s. |
+| `--live` | Compare the single `--config` against the cluster: the live XRD/CRD supplies the schema, and the `XRDConversionConfig`/`CRDConversionConfig` of the same name supplies the other side. |
+| `--kubeconfig` | Path to a kubeconfig file. Only used with `--live`. Resolves exactly like `kubectl`. |
+| `--context` | Kubeconfig context to use. Only used with `--live`. |
+| `-o, --output` | `json` (default) or `table`. |
+
+The report is per-spoke, listing:
+
+- hub and spoke fields that became uncovered, and ones that became covered
+- rule claims added and removed, identified by strategy plus the hub/spoke paths they claim (so reordering rules is correctly *not* a difference)
+- lossless flags that flipped, per direction
+- error and warning messages that appeared or disappeared
+
+Plus, at the top level, a hub-version change and any spoke version added or removed outright.
+
+With `--live`, the cluster is always the *from* side and the local file is the *to* side, so the diff reads as "what applying this file would change". If the cluster has no config of that name yet, the from side becomes an empty rule set over the same spoke versions — every rule in your file shows up as an addition, which is a far more useful answer than refusing to run.
+
+Exit codes are `0` when the two sides are equivalent, `1` when any delta is found, and `2` for usage or load errors — so `convctl diff` drops straight into a CI gate that fails a PR whose config change wasn't intended.
 
 ## Pre-upgrade checks: testing against everything that already exists
 

--- a/internal/cli/concurrency_test.go
+++ b/internal/cli/concurrency_test.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2026 The declarative-conversion-operator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+// normalizeForComparison strips the fields that legitimately differ between
+// two runs of the same input — wall-clock timings and the generation
+// timestamp — so everything left over must match exactly.
+func normalizeForComparison(rep *Report) {
+	rep.Meta.DurationMs = 0
+	rep.Meta.GeneratedAt = ""
+	for i := range rep.Samples {
+		for j := range rep.Samples[i].Paths {
+			rep.Samples[i].Paths[j].TimingMicros = 0
+		}
+	}
+	sort.Slice(rep.RuleCoverage, func(i, j int) bool { return rep.RuleCoverage[i].RuleID < rep.RuleCoverage[j].RuleID })
+}
+
+// TestRunTest_ConcurrencyIsFunctionallyEquivalent is the whole contract of
+// the worker pool: more workers must change nothing about the report,
+// including the order samples appear in.
+func TestRunTest_ConcurrencyIsFunctionallyEquivalent(t *testing.T) {
+	base := TestOptions{
+		XRDPath:    "testdata/full/xrd.yaml",
+		ConfigPath: "testdata/full/config.yaml",
+		SamplesDir: "testdata/full/samples",
+		Quiet:      true,
+	}
+
+	serialOpts := base
+	serialOpts.Concurrency = 1
+	serial, err := RunTest(serialOpts)
+	if err != nil {
+		t.Fatalf("serial run: %v", err)
+	}
+	normalizeForComparison(serial)
+
+	for _, n := range []int{2, 4, 16} {
+		opts := base
+		opts.Concurrency = n
+		parallel, err := RunTest(opts)
+		if err != nil {
+			t.Fatalf("run with concurrency %d: %v", n, err)
+		}
+		normalizeForComparison(parallel)
+		if !reflect.DeepEqual(serial, parallel) {
+			t.Fatalf("concurrency %d produced a different report:\nserial:   %+v\nparallel: %+v", n, serial, parallel)
+		}
+	}
+}
+
+// TestRunTest_SampleOrderIsDeterministic pins the ordering guarantee
+// separately, since a DeepEqual failure alone wouldn't say whether the
+// contents or just the order drifted.
+func TestRunTest_SampleOrderIsDeterministic(t *testing.T) {
+	want, err := LoadSamples("testdata/full/samples")
+	if err != nil {
+		t.Fatalf("load samples: %v", err)
+	}
+
+	for _, n := range []int{1, 3, 8} {
+		rep, err := RunTest(TestOptions{
+			XRDPath:     "testdata/full/xrd.yaml",
+			ConfigPath:  "testdata/full/config.yaml",
+			SamplesDir:  "testdata/full/samples",
+			Quiet:       true,
+			Concurrency: n,
+		})
+		if err != nil {
+			t.Fatalf("run with concurrency %d: %v", n, err)
+		}
+		if len(rep.Samples) != len(want) {
+			t.Fatalf("concurrency %d: got %d sample results, want %d", n, len(rep.Samples), len(want))
+		}
+		for i := range want {
+			if rep.Samples[i].File != want[i].File {
+				t.Fatalf("concurrency %d: sample %d is %q, want %q (load order)", n, i, rep.Samples[i].File, want[i].File)
+			}
+		}
+	}
+}
+
+func TestEffectiveConcurrency(t *testing.T) {
+	cases := []struct {
+		requested, samples, want int
+	}{
+		{requested: 4, samples: 10, want: 4},
+		{requested: 4, samples: 2, want: 2},
+		{requested: -1, samples: 1, want: 1},
+		{requested: 0, samples: 1, want: 1},
+		{requested: 1, samples: 0, want: 1},
+	}
+	for _, c := range cases {
+		if got := (TestOptions{Concurrency: c.requested}).effectiveConcurrency(c.samples); got != c.want {
+			t.Errorf("effectiveConcurrency(requested=%d, samples=%d) = %d, want %d", c.requested, c.samples, got, c.want)
+		}
+	}
+	// An unset Concurrency scales with the machine, but never below one
+	// worker even on a single-CPU runner.
+	if got := (TestOptions{}).effectiveConcurrency(1000); got < 1 {
+		t.Errorf("default concurrency = %d, want at least 1", got)
+	}
+}

--- a/internal/cli/configdiff.go
+++ b/internal/cli/configdiff.go
@@ -1,0 +1,471 @@
+/*
+Copyright 2026 The declarative-conversion-operator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	teraskyv1alpha1 "github.com/terasky-oss/declarative-conversion-operator/api/v1alpha1"
+	"github.com/terasky-oss/declarative-conversion-operator/pkg/engine"
+)
+
+// DiffOptions configures RunDiff.
+type DiffOptions struct {
+	// ConfigPaths holds exactly two config files to compare, or exactly
+	// one when Live is set (the local side of a local-vs-cluster diff).
+	ConfigPaths []string
+	XRDPath     string
+	CRDPath     string
+
+	// Live compares ConfigPaths[0] against whatever the cluster currently
+	// has: the live XRD/CRD schema, and the ConversionConfig of the same
+	// name if one exists.
+	Live        bool
+	Kubeconfig  string
+	KubeContext string
+}
+
+// DiffOutput is the delta between two conversion configs analyzed against
+// the same schema — what changes about coverage, which rules claim which
+// paths, whether each direction is still lossless, and which diagnostics
+// appear or disappear.
+type DiffOutput struct {
+	ResourceKind string `json:"resourceKind"` // "XRD" or "CRD"
+	Resource     string `json:"resource"`
+	// From and To label the two sides being compared, in that order: a
+	// file path, or "cluster:<name>" for the live side.
+	From      string `json:"from"`
+	To        string `json:"to"`
+	HasDeltas bool   `json:"hasDeltas"`
+	// HubVersionChange is set only when the two sides disagree about which
+	// version is the hub — a change that reshapes every spoke's mapping.
+	HubVersionChange *StringChange `json:"hubVersionChange,omitempty"`
+	SpokesAdded      []string      `json:"spokesAdded,omitempty"`
+	SpokesRemoved    []string      `json:"spokesRemoved,omitempty"`
+	Spokes           []SpokeDiff   `json:"spokes,omitempty"`
+}
+
+// StringChange is a single scalar that differs between the two sides.
+type StringChange struct {
+	From string `json:"from"`
+	To   string `json:"to"`
+}
+
+// RuleClaim is the set of hub and spoke paths one rule claims, identified
+// by strategy rather than by index — reordering a config's rules is not a
+// semantic change, and shouldn't show up as one.
+type RuleClaim struct {
+	Strategy   string   `json:"strategy"`
+	HubPaths   []string `json:"hubPaths,omitempty"`
+	SpokePaths []string `json:"spokePaths,omitempty"`
+}
+
+// LosslessChange records one direction of one spoke flipping between
+// lossless and lossy.
+type LosslessChange struct {
+	Direction string `json:"direction"` // "hubToSpoke" | "spokeToHub"
+	From      bool   `json:"from"`
+	To        bool   `json:"to"`
+}
+
+// SpokeDiff is everything that changed for one spoke version present on
+// both sides.
+type SpokeDiff struct {
+	Version               string           `json:"version"`
+	UncoveredHubAdded     []string         `json:"uncoveredHubAdded,omitempty"`
+	UncoveredHubRemoved   []string         `json:"uncoveredHubRemoved,omitempty"`
+	UncoveredSpokeAdded   []string         `json:"uncoveredSpokeAdded,omitempty"`
+	UncoveredSpokeRemoved []string         `json:"uncoveredSpokeRemoved,omitempty"`
+	RuleClaimsAdded       []RuleClaim      `json:"ruleClaimsAdded,omitempty"`
+	RuleClaimsRemoved     []RuleClaim      `json:"ruleClaimsRemoved,omitempty"`
+	LosslessChanges       []LosslessChange `json:"losslessChanges,omitempty"`
+	ErrorsAdded           []string         `json:"errorsAdded,omitempty"`
+	ErrorsRemoved         []string         `json:"errorsRemoved,omitempty"`
+	WarningsAdded         []string         `json:"warningsAdded,omitempty"`
+	WarningsRemoved       []string         `json:"warningsRemoved,omitempty"`
+}
+
+func (s SpokeDiff) hasDeltas() bool {
+	return len(s.UncoveredHubAdded)+len(s.UncoveredHubRemoved)+
+		len(s.UncoveredSpokeAdded)+len(s.UncoveredSpokeRemoved)+
+		len(s.RuleClaimsAdded)+len(s.RuleClaimsRemoved)+
+		len(s.LosslessChanges)+
+		len(s.ErrorsAdded)+len(s.ErrorsRemoved)+
+		len(s.WarningsAdded)+len(s.WarningsRemoved) > 0
+}
+
+// RunDiff analyzes both sides against the same schema and reports what
+// changed. Which of XRDPath/CRDPath applies is determined by the config's
+// own kind, as everywhere else.
+func RunDiff(opts DiffOptions) (*DiffOutput, error) {
+	if opts.Live {
+		if len(opts.ConfigPaths) != 1 {
+			return nil, fmt.Errorf("--live compares exactly one local --config against the cluster; got %d", len(opts.ConfigPaths))
+		}
+	} else if len(opts.ConfigPaths) != 2 {
+		return nil, fmt.Errorf("diff needs exactly two --config paths (or one with --live); got %d", len(opts.ConfigPaths))
+	}
+
+	kind, err := PeekConfigKind(opts.ConfigPaths[0])
+	if err != nil {
+		return nil, err
+	}
+	if opts.Live {
+		return runDiffLive(kind, opts)
+	}
+	return runDiffFiles(kind, opts)
+}
+
+func runDiffFiles(kind string, opts DiffOptions) (*DiffOutput, error) {
+	otherKind, err := PeekConfigKind(opts.ConfigPaths[1])
+	if err != nil {
+		return nil, err
+	}
+	if otherKind != kind {
+		return nil, fmt.Errorf("cannot diff a %s against a %s", kind, otherKind)
+	}
+
+	if kind == "CRDConversionConfig" {
+		if opts.CRDPath == "" {
+			return nil, fmt.Errorf("%s is a CRDConversionConfig; pass its target schema with --crd, not --xrd", opts.ConfigPaths[0])
+		}
+		crd, err := LoadCRD(opts.CRDPath)
+		if err != nil {
+			return nil, err
+		}
+		from, err := LoadCRDConfig(opts.ConfigPaths[0])
+		if err != nil {
+			return nil, err
+		}
+		to, err := LoadCRDConfig(opts.ConfigPaths[1])
+		if err != nil {
+			return nil, err
+		}
+		return diffCRDConfigs(crd, from, to, opts.ConfigPaths[0], opts.ConfigPaths[1])
+	}
+
+	if opts.XRDPath == "" {
+		return nil, fmt.Errorf("%s is an XRDConversionConfig; pass its target schema with --xrd, not --crd", opts.ConfigPaths[0])
+	}
+	xrd, err := LoadXRD(opts.XRDPath)
+	if err != nil {
+		return nil, err
+	}
+	from, err := LoadConfig(opts.ConfigPaths[0])
+	if err != nil {
+		return nil, err
+	}
+	to, err := LoadConfig(opts.ConfigPaths[1])
+	if err != nil {
+		return nil, err
+	}
+	return diffXRDConfigs(xrd, from, to, opts.ConfigPaths[0], opts.ConfigPaths[1])
+}
+
+// runDiffLive compares the cluster's current state (the "from" side)
+// against the local config (the "to" side), which is the direction that
+// makes a diff read like "what applying this would change".
+func runDiffLive(kind string, opts DiffOptions) (*DiffOutput, error) {
+	dyn, err := buildDynamicClient(KubeOptions{Kubeconfig: opts.Kubeconfig, Context: opts.KubeContext})
+	if err != nil {
+		return nil, err
+	}
+	ctx := context.Background()
+
+	if kind == "CRDConversionConfig" {
+		local, err := LoadCRDConfig(opts.ConfigPaths[0])
+		if err != nil {
+			return nil, err
+		}
+		crd, err := FetchLiveCRD(ctx, dyn, local.Spec.TargetCRD.Name)
+		if err != nil {
+			return nil, err
+		}
+		live, err := FetchLiveCRDConversionConfig(ctx, dyn, local.Name)
+		if err != nil {
+			return nil, err
+		}
+		fromLabel := "cluster:" + local.Name
+		if live == nil {
+			live = emptyRulesCRDConfig(local)
+			fromLabel = "cluster:(no CRDConversionConfig " + local.Name + ")"
+		}
+		return diffCRDConfigs(crd, live, local, fromLabel, opts.ConfigPaths[0])
+	}
+
+	local, err := LoadConfig(opts.ConfigPaths[0])
+	if err != nil {
+		return nil, err
+	}
+	xrd, err := FetchLiveXRD(ctx, dyn, local.Spec.TargetXRD.Name)
+	if err != nil {
+		return nil, err
+	}
+	live, err := FetchLiveXRDConversionConfig(ctx, dyn, local.Name)
+	if err != nil {
+		return nil, err
+	}
+	fromLabel := "cluster:" + local.Name
+	if live == nil {
+		live = emptyRulesXRDConfig(local)
+		fromLabel = "cluster:(no XRDConversionConfig " + local.Name + ")"
+	}
+	return diffXRDConfigs(xrd, live, local, fromLabel, opts.ConfigPaths[0])
+}
+
+func diffXRDConfigs(xrd *unstructured.Unstructured, from, to *teraskyv1alpha1.XRDConversionConfig, fromLabel, toLabel string) (*DiffOutput, error) {
+	fromReport, _, err := runAnalyze(xrd, from)
+	if err != nil {
+		return nil, fmt.Errorf("analyzing %s: %w", fromLabel, err)
+	}
+	toReport, _, err := runAnalyze(xrd, to)
+	if err != nil {
+		return nil, fmt.Errorf("analyzing %s: %w", toLabel, err)
+	}
+	return buildDiffOutput("XRD", xrdName(xrd), fromLabel, toLabel, from.Spec.HubVersion, to.Spec.HubVersion, fromReport, toReport), nil
+}
+
+func diffCRDConfigs(crd *extv1.CustomResourceDefinition, from, to *teraskyv1alpha1.CRDConversionConfig, fromLabel, toLabel string) (*DiffOutput, error) {
+	fromReport, _, err := runAnalyzeCRD(crd, from)
+	if err != nil {
+		return nil, fmt.Errorf("analyzing %s: %w", fromLabel, err)
+	}
+	toReport, _, err := runAnalyzeCRD(crd, to)
+	if err != nil {
+		return nil, fmt.Errorf("analyzing %s: %w", toLabel, err)
+	}
+	return buildDiffOutput("CRD", crdName(crd), fromLabel, toLabel, from.Spec.HubVersion, to.Spec.HubVersion, fromReport, toReport), nil
+}
+
+// emptyRulesXRDConfig mirrors cfg's spokes with no rules at all, standing
+// in for the cluster side when no config has been applied yet: diffing
+// against "every field unclaimed" is far more useful than refusing to run.
+func emptyRulesXRDConfig(cfg *teraskyv1alpha1.XRDConversionConfig) *teraskyv1alpha1.XRDConversionConfig {
+	out := &teraskyv1alpha1.XRDConversionConfig{}
+	out.Name = cfg.Name
+	out.Spec.TargetXRD = cfg.Spec.TargetXRD
+	out.Spec.HubVersion = cfg.Spec.HubVersion
+	out.Spec.UnmappedFieldPolicy = cfg.Spec.UnmappedFieldPolicy
+	for _, s := range cfg.Spec.Spokes {
+		out.Spec.Spokes = append(out.Spec.Spokes, teraskyv1alpha1.SpokeVersionRules{Version: s.Version})
+	}
+	return out
+}
+
+func emptyRulesCRDConfig(cfg *teraskyv1alpha1.CRDConversionConfig) *teraskyv1alpha1.CRDConversionConfig {
+	out := &teraskyv1alpha1.CRDConversionConfig{}
+	out.Name = cfg.Name
+	out.Spec.TargetCRD = cfg.Spec.TargetCRD
+	out.Spec.HubVersion = cfg.Spec.HubVersion
+	out.Spec.UnmappedFieldPolicy = cfg.Spec.UnmappedFieldPolicy
+	for _, s := range cfg.Spec.Spokes {
+		out.Spec.Spokes = append(out.Spec.Spokes, teraskyv1alpha1.SpokeVersionRules{Version: s.Version})
+	}
+	return out
+}
+
+func buildDiffOutput(resourceKind, resourceName, fromLabel, toLabel, fromHub, toHub string, from, to engine.AnalyzeReport) *DiffOutput {
+	out := &DiffOutput{ResourceKind: resourceKind, Resource: resourceName, From: fromLabel, To: toLabel}
+	if fromHub != toHub {
+		out.HubVersionChange = &StringChange{From: fromHub, To: toHub}
+	}
+
+	fromSpokes := spokeReportsByVersion(from)
+	toSpokes := spokeReportsByVersion(to)
+	for _, v := range sortedKeys(toSpokes) {
+		if _, ok := fromSpokes[v]; !ok {
+			out.SpokesAdded = append(out.SpokesAdded, v)
+		}
+	}
+	for _, v := range sortedKeys(fromSpokes) {
+		if _, ok := toSpokes[v]; !ok {
+			out.SpokesRemoved = append(out.SpokesRemoved, v)
+		}
+	}
+
+	for _, v := range sortedKeys(toSpokes) {
+		f, ok := fromSpokes[v]
+		if !ok {
+			continue
+		}
+		if sd := diffSpokeReports(v, f, toSpokes[v]); sd.hasDeltas() {
+			out.Spokes = append(out.Spokes, sd)
+		}
+	}
+
+	out.HasDeltas = out.HubVersionChange != nil || len(out.SpokesAdded) > 0 || len(out.SpokesRemoved) > 0 || len(out.Spokes) > 0
+	return out
+}
+
+func diffSpokeReports(version string, from, to engine.SpokeReport) SpokeDiff {
+	sd := SpokeDiff{Version: version}
+	sd.UncoveredHubAdded, sd.UncoveredHubRemoved = stringSetDiff(from.Uncovered.UncoveredHub, to.Uncovered.UncoveredHub)
+	sd.UncoveredSpokeAdded, sd.UncoveredSpokeRemoved = stringSetDiff(from.Uncovered.UncoveredSpoke, to.Uncovered.UncoveredSpoke)
+	sd.RuleClaimsAdded, sd.RuleClaimsRemoved = claimSetDiff(ruleClaims(from), ruleClaims(to))
+	if from.Lossless.HubToSpoke != to.Lossless.HubToSpoke {
+		sd.LosslessChanges = append(sd.LosslessChanges, LosslessChange{Direction: "hubToSpoke", From: from.Lossless.HubToSpoke, To: to.Lossless.HubToSpoke})
+	}
+	if from.Lossless.SpokeToHub != to.Lossless.SpokeToHub {
+		sd.LosslessChanges = append(sd.LosslessChanges, LosslessChange{Direction: "spokeToHub", From: from.Lossless.SpokeToHub, To: to.Lossless.SpokeToHub})
+	}
+	sd.ErrorsAdded, sd.ErrorsRemoved = stringSetDiff(diagMessages(from.Errors), diagMessages(to.Errors))
+	sd.WarningsAdded, sd.WarningsRemoved = stringSetDiff(diagMessages(from.Warnings), diagMessages(to.Warnings))
+	return sd
+}
+
+func spokeReportsByVersion(r engine.AnalyzeReport) map[string]engine.SpokeReport {
+	out := map[string]engine.SpokeReport{}
+	for _, sr := range r.SpokeReports {
+		out[sr.Version] = sr
+	}
+	return out
+}
+
+func sortedKeys[V any](m map[string]V) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func diagMessages(ds []engine.Diagnostic) []string {
+	out := make([]string, 0, len(ds))
+	for _, d := range ds {
+		out = append(out, d.Message)
+	}
+	return out
+}
+
+// stringSetDiff reports which entries appear only in to (added) and only in
+// from (removed), as sorted sets — duplicates carry no meaning for any of
+// the path/message lists this compares.
+func stringSetDiff(from, to []string) (added, removed []string) {
+	fromSet := map[string]bool{}
+	for _, s := range from {
+		fromSet[s] = true
+	}
+	toSet := map[string]bool{}
+	for _, s := range to {
+		toSet[s] = true
+	}
+	for s := range toSet {
+		if !fromSet[s] {
+			added = append(added, s)
+		}
+	}
+	for s := range fromSet {
+		if !toSet[s] {
+			removed = append(removed, s)
+		}
+	}
+	sort.Strings(added)
+	sort.Strings(removed)
+	return added, removed
+}
+
+func ruleClaims(sr engine.SpokeReport) []RuleClaim {
+	out := make([]RuleClaim, 0, len(sr.RuleResults))
+	for _, rr := range sr.RuleResults {
+		out = append(out, RuleClaim{Strategy: string(rr.Strategy), HubPaths: rr.HubPaths, SpokePaths: rr.SpokePaths})
+	}
+	return out
+}
+
+// claimSetDiff is a multiset diff: two rules with the same strategy
+// claiming the same paths are interchangeable, but declaring the same rule
+// twice and declaring it once are genuinely different configs.
+func claimSetDiff(from, to []RuleClaim) (added, removed []RuleClaim) {
+	counts := map[string]int{}
+	byKey := map[string]RuleClaim{}
+	for _, c := range from {
+		k := claimKey(c)
+		counts[k]--
+		byKey[k] = c
+	}
+	for _, c := range to {
+		k := claimKey(c)
+		counts[k]++
+		byKey[k] = c
+	}
+	for _, k := range sortedKeys(counts) {
+		for i := 0; i < counts[k]; i++ {
+			added = append(added, byKey[k])
+		}
+		for i := 0; i > counts[k]; i-- {
+			removed = append(removed, byKey[k])
+		}
+	}
+	return added, removed
+}
+
+func claimKey(c RuleClaim) string {
+	return fmt.Sprintf("%s|%s|%s", c.Strategy, strings.Join(c.HubPaths, ","), strings.Join(c.SpokePaths, ","))
+}
+
+// WriteTable renders the diff for a terminal. Write errors to a
+// terminal/CI log capture are not actionable, so they're deliberately
+// ignored here, as elsewhere in this package.
+func (d *DiffOutput) WriteTable(w io.Writer) {
+	_, _ = fmt.Fprintf(w, "%s Conversion Diff\n%s: %s\n%s → %s\n\n", d.ResourceKind, d.ResourceKind, d.Resource, d.From, d.To)
+	if !d.HasDeltas {
+		_, _ = fmt.Fprintln(w, "no differences")
+		return
+	}
+	if d.HubVersionChange != nil {
+		_, _ = fmt.Fprintf(w, "hub version: %s → %s\n", d.HubVersionChange.From, d.HubVersionChange.To)
+	}
+	for _, v := range d.SpokesAdded {
+		_, _ = fmt.Fprintf(w, "+ spoke %s\n", v)
+	}
+	for _, v := range d.SpokesRemoved {
+		_, _ = fmt.Fprintf(w, "- spoke %s\n", v)
+	}
+	for _, s := range d.Spokes {
+		_, _ = fmt.Fprintf(w, "\n[spoke %s]\n", s.Version)
+		for _, c := range s.LosslessChanges {
+			_, _ = fmt.Fprintf(w, "  lossless %s: %v → %v\n", c.Direction, c.From, c.To)
+		}
+		writePathDeltas(w, "uncovered hub", s.UncoveredHubAdded, s.UncoveredHubRemoved)
+		writePathDeltas(w, "uncovered spoke", s.UncoveredSpokeAdded, s.UncoveredSpokeRemoved)
+		for _, c := range s.RuleClaimsAdded {
+			_, _ = fmt.Fprintf(w, "  + rule %s\n", claimKey(c))
+		}
+		for _, c := range s.RuleClaimsRemoved {
+			_, _ = fmt.Fprintf(w, "  - rule %s\n", claimKey(c))
+		}
+		writePathDeltas(w, "ERROR", s.ErrorsAdded, s.ErrorsRemoved)
+		writePathDeltas(w, "WARNING", s.WarningsAdded, s.WarningsRemoved)
+	}
+}
+
+func writePathDeltas(w io.Writer, label string, added, removed []string) {
+	for _, p := range added {
+		_, _ = fmt.Fprintf(w, "  + %s %s\n", label, p)
+	}
+	for _, p := range removed {
+		_, _ = fmt.Fprintf(w, "  - %s %s\n", label, p)
+	}
+}

--- a/internal/cli/configdiff_test.go
+++ b/internal/cli/configdiff_test.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2026 The declarative-conversion-operator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"testing"
+)
+
+func TestRunDiff_IdenticalConfigsAreClean(t *testing.T) {
+	out, err := RunDiff(DiffOptions{
+		ConfigPaths: []string{"testdata/config.yaml", "testdata/config.yaml"},
+		XRDPath:     "testdata/xrd.yaml",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.HasDeltas {
+		t.Fatalf("expected no deltas between a config and itself, got %+v", out)
+	}
+	if len(out.Spokes) != 0 || len(out.SpokesAdded) != 0 || len(out.SpokesRemoved) != 0 {
+		t.Fatalf("expected an entirely empty diff, got %+v", out)
+	}
+}
+
+// TestRunDiff_DroppedFieldRename asserts the whole chain a real review
+// cares about: the rename's claim disappears, both of the paths it used to
+// cover become uncovered, and new errors are reported for them.
+func TestRunDiff_DroppedFieldRename(t *testing.T) {
+	out, err := RunDiff(DiffOptions{
+		ConfigPaths: []string{"testdata/config.yaml", "testdata/config-norename.yaml"},
+		XRDPath:     "testdata/xrd.yaml",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !out.HasDeltas {
+		t.Fatalf("expected deltas after dropping a FieldRename rule, got %+v", out)
+	}
+	if out.ResourceKind != "XRD" || out.Resource != "xfoos.example.org" {
+		t.Fatalf("unexpected diff target: %s %s", out.ResourceKind, out.Resource)
+	}
+	if len(out.Spokes) != 1 || out.Spokes[0].Version != "v1" {
+		t.Fatalf("expected exactly one changed spoke (v1), got %+v", out.Spokes)
+	}
+	sd := out.Spokes[0]
+
+	if len(sd.RuleClaimsRemoved) != 1 || sd.RuleClaimsRemoved[0].Strategy != "FieldRename" {
+		t.Fatalf("expected the FieldRename claim to be reported as removed, got %+v", sd.RuleClaimsRemoved)
+	}
+	claim := sd.RuleClaimsRemoved[0]
+	if len(claim.HubPaths) != 1 || claim.HubPaths[0] != "spec.storageGB" {
+		t.Fatalf("expected the removed claim to name spec.storageGB, got %+v", claim.HubPaths)
+	}
+	if len(claim.SpokePaths) != 1 || claim.SpokePaths[0] != "spec.storageSize" {
+		t.Fatalf("expected the removed claim to name spec.storageSize, got %+v", claim.SpokePaths)
+	}
+	if len(sd.RuleClaimsAdded) != 0 {
+		t.Fatalf("expected no added claims, got %+v", sd.RuleClaimsAdded)
+	}
+
+	if len(sd.UncoveredHubAdded) != 1 || sd.UncoveredHubAdded[0] != "spec.storageGB" {
+		t.Fatalf("expected spec.storageGB to become uncovered on the hub side, got %+v", sd.UncoveredHubAdded)
+	}
+	if len(sd.UncoveredSpokeAdded) != 1 || sd.UncoveredSpokeAdded[0] != "spec.storageSize" {
+		t.Fatalf("expected spec.storageSize to become uncovered on the spoke side, got %+v", sd.UncoveredSpokeAdded)
+	}
+	if len(sd.ErrorsAdded) == 0 {
+		t.Fatalf("expected new error diagnostics for the now-uncovered fields")
+	}
+	if len(sd.ErrorsRemoved) != 0 {
+		t.Fatalf("expected no errors to disappear, got %+v", sd.ErrorsRemoved)
+	}
+}
+
+// TestRunDiff_AgainstEmptyRules covers what --live falls back to when the
+// cluster has no config applied yet: every rule the local config declares
+// shows up as an addition against a same-spokes, zero-rule baseline.
+func TestRunDiff_AgainstEmptyRules(t *testing.T) {
+	xrd, err := LoadXRD("testdata/xrd.yaml")
+	if err != nil {
+		t.Fatalf("load xrd: %v", err)
+	}
+	local, err := LoadConfig("testdata/config.yaml")
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+
+	out, err := diffXRDConfigs(xrd, emptyRulesXRDConfig(local), local, "cluster:(none)", "testdata/config.yaml")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !out.HasDeltas || len(out.Spokes) != 1 {
+		t.Fatalf("expected deltas on the single spoke, got %+v", out)
+	}
+	if len(out.Spokes[0].RuleClaimsAdded) != 2 {
+		t.Fatalf("expected both declared rules to be reported as added, got %+v", out.Spokes[0].RuleClaimsAdded)
+	}
+	if len(out.Spokes[0].ErrorsRemoved) == 0 {
+		t.Fatalf("expected the baseline's uncovered-field errors to be resolved by the local config")
+	}
+}
+
+func TestRunDiff_UsageErrors(t *testing.T) {
+	cases := map[string]DiffOptions{
+		"one config without --live": {ConfigPaths: []string{"testdata/config.yaml"}, XRDPath: "testdata/xrd.yaml"},
+		"three configs":             {ConfigPaths: []string{"testdata/config.yaml", "testdata/config.yaml", "testdata/config.yaml"}, XRDPath: "testdata/xrd.yaml"},
+		"two configs with --live":   {ConfigPaths: []string{"testdata/config.yaml", "testdata/config.yaml"}, Live: true},
+		"missing schema":            {ConfigPaths: []string{"testdata/config.yaml", "testdata/config.yaml"}},
+		"mismatched kinds":          {ConfigPaths: []string{"testdata/config.yaml", "testdata/crdconfig.yaml"}, XRDPath: "testdata/xrd.yaml"},
+	}
+	for name, opts := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := RunDiff(opts); err == nil {
+				t.Fatalf("expected an error for %s", name)
+			}
+		})
+	}
+}
+
+func TestRunDiff_CRDConfigs(t *testing.T) {
+	out, err := RunDiff(DiffOptions{
+		ConfigPaths: []string{"testdata/crdconfig.yaml", "testdata/crdconfig.yaml"},
+		CRDPath:     "testdata/crd.yaml",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.ResourceKind != "CRD" {
+		t.Fatalf("expected a CRD diff, got %q", out.ResourceKind)
+	}
+	if out.HasDeltas {
+		t.Fatalf("expected no deltas between a config and itself, got %+v", out)
+	}
+}

--- a/internal/cli/convert.go
+++ b/internal/cli/convert.go
@@ -1,0 +1,215 @@
+/*
+Copyright 2026 The declarative-conversion-operator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	sigsyaml "sigs.k8s.io/yaml"
+
+	"github.com/terasky-oss/declarative-conversion-operator/pkg/engine"
+)
+
+// ConvertOptions configures RunConvert.
+type ConvertOptions struct {
+	XRDPath    string
+	CRDPath    string
+	ConfigPath string
+	// SamplePath is a single-document YAML/JSON file holding the object to
+	// convert.
+	SamplePath string
+	// To is the version to convert into.
+	To string
+	// From overrides the version inferred from the sample's own
+	// apiVersion, for objects that don't carry one (or carry a wrong one).
+	From string
+}
+
+// RunConvert converts one object between two versions through the exact
+// same compiled plan the webhook server would use, and returns the
+// converted object. Which of XRDPath/CRDPath applies is determined by the
+// config's own kind.
+func RunConvert(opts ConvertOptions) (map[string]any, error) {
+	if opts.To == "" {
+		return nil, fmt.Errorf("--to is required: name the version to convert into")
+	}
+	sample, err := loadSingleSample(opts.SamplePath)
+	if err != nil {
+		return nil, err
+	}
+	from := opts.From
+	if from == "" {
+		from = sample.Version
+	}
+	if from == "" {
+		return nil, fmt.Errorf("%s has no apiVersion to infer the source version from; pass --from", opts.SamplePath)
+	}
+
+	kind, err := PeekConfigKind(opts.ConfigPath)
+	if err != nil {
+		return nil, err
+	}
+	if kind == "CRDConversionConfig" {
+		if opts.CRDPath == "" {
+			return nil, fmt.Errorf("%s is a CRDConversionConfig; pass its target schema with --crd, not --xrd", opts.ConfigPath)
+		}
+		crd, err := LoadCRD(opts.CRDPath)
+		if err != nil {
+			return nil, err
+		}
+		cfg, err := LoadCRDConfig(opts.ConfigPath)
+		if err != nil {
+			return nil, err
+		}
+		report, _, err := runAnalyzeCRD(crd, cfg)
+		if err != nil {
+			return nil, err
+		}
+		if report.HasErrors() {
+			return nil, fmt.Errorf("configuration is invalid against the CRD schema, cannot convert:%s", summarizeSpokeErrors(report))
+		}
+		router, err := buildRouterCRD(cfg, report)
+		if err != nil {
+			return nil, err
+		}
+		return convertOne(router, sample.Object, from, opts.To, crd.Spec.Group)
+	}
+
+	if opts.XRDPath == "" {
+		return nil, fmt.Errorf("%s is an XRDConversionConfig; pass its target schema with --xrd, not --crd", opts.ConfigPath)
+	}
+	xrd, err := LoadXRD(opts.XRDPath)
+	if err != nil {
+		return nil, err
+	}
+	cfg, err := LoadConfig(opts.ConfigPath)
+	if err != nil {
+		return nil, err
+	}
+	report, _, err := runAnalyze(xrd, cfg)
+	if err != nil {
+		return nil, err
+	}
+	if report.HasErrors() {
+		return nil, fmt.Errorf("configuration is invalid against the XRD schema, cannot convert:%s", summarizeSpokeErrors(report))
+	}
+	router, err := buildRouter(cfg, report)
+	if err != nil {
+		return nil, err
+	}
+	group, _, err := xrdResourceInfo(xrd)
+	if err != nil {
+		return nil, err
+	}
+	return convertOne(router, sample.Object, from, opts.To, group)
+}
+
+// convertOne runs the conversion and stamps the output's apiVersion, which
+// the engine deliberately never sets itself: a Plan knows the version names
+// it maps between, but only the schema knows the API group they live under.
+func convertOne(router *engine.Router, obj map[string]any, from, to, group string) (map[string]any, error) {
+	out, err := router.Convert(obj, from, to)
+	if err != nil {
+		return nil, err
+	}
+	// Router.Convert returns the input untouched for a same-version
+	// request, so copy before stamping rather than mutating the caller's
+	// object.
+	converted := make(map[string]any, len(out)+1)
+	for k, v := range out {
+		converted[k] = v
+	}
+	if group == "" {
+		return nil, fmt.Errorf("cannot determine the API group to stamp on the converted object")
+	}
+	converted["apiVersion"] = group + "/" + to
+	return converted, nil
+}
+
+// loadSingleSample reads exactly one object from path. A multi-document
+// file is rejected rather than silently converting only its first
+// document.
+func loadSingleSample(path string) (Sample, error) {
+	if path == "" {
+		return Sample{}, fmt.Errorf("--sample is required: pass the object to convert")
+	}
+	docs, err := decodeAllDocuments(path)
+	if err != nil {
+		return Sample{}, fmt.Errorf("reading %s: %w", path, err)
+	}
+	switch len(docs) {
+	case 0:
+		return Sample{}, fmt.Errorf("%s contains no objects", path)
+	case 1:
+	default:
+		return Sample{}, fmt.Errorf("%s contains %d documents; convert takes exactly one object", path, len(docs))
+	}
+	apiVersion, _ := docs[0]["apiVersion"].(string)
+	return Sample{File: path, Object: docs[0], Version: versionFromAPIVersion(apiVersion)}, nil
+}
+
+func newConvertCmd() *cobra.Command {
+	var xrdPath, crdPath, configPath, samplePath, to, from, output string
+	cmd := &cobra.Command{
+		Use:   "convert",
+		Short: "Convert a single object between two versions",
+		Long: `Run one object through the conversion config and print the result — the same
+compiled plan the webhook server would execute, minus the cluster.
+
+The source version is inferred from the object's own apiVersion (override it with
+--from), and the converted output's apiVersion is rewritten to the target version
+under the group declared by the XRD or CRD. Spoke-to-spoke conversions route
+through the hub exactly as they do in production.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			switch output {
+			case "yaml", "json":
+			default:
+				return fmt.Errorf("invalid --output value %q (want yaml or json)", output)
+			}
+			obj, err := RunConvert(ConvertOptions{
+				XRDPath: xrdPath, CRDPath: crdPath, ConfigPath: configPath,
+				SamplePath: samplePath, To: to, From: from,
+			})
+			if err != nil {
+				return err
+			}
+			if output == "json" {
+				return writeJSON(cmd, obj)
+			}
+			data, err := sigsyaml.Marshal(obj)
+			if err != nil {
+				return fmt.Errorf("rendering YAML: %w", err)
+			}
+			_, err = cmd.OutOrStdout().Write(data)
+			return err
+		},
+	}
+	cmd.Flags().StringVarP(&xrdPath, "xrd", "x", "", "Path to an XRD YAML file (required for an XRDConversionConfig)")
+	cmd.Flags().StringVar(&crdPath, "crd", "", "Path to a CRD YAML file (required for a CRDConversionConfig)")
+	cmd.Flags().StringVarP(&configPath, "config", "c", "", "Path to an XRDConversionConfig or CRDConversionConfig YAML file (required)")
+	cmd.Flags().StringVar(&samplePath, "sample", "", "Path to a single-document YAML file holding the object to convert (required)")
+	cmd.Flags().StringVar(&to, "to", "", "Version to convert into (required)")
+	cmd.Flags().StringVar(&from, "from", "", "Source version (default: inferred from the sample's own apiVersion)")
+	cmd.Flags().StringVarP(&output, "output", "o", "yaml", "Output format: yaml|json")
+	_ = cmd.MarkFlagRequired("config")
+	_ = cmd.MarkFlagRequired("sample")
+	_ = cmd.MarkFlagRequired("to")
+	cmd.MarkFlagsOneRequired("xrd", "crd")
+	cmd.MarkFlagsMutuallyExclusive("xrd", "crd")
+	return cmd
+}

--- a/internal/cli/convert_test.go
+++ b/internal/cli/convert_test.go
@@ -63,7 +63,10 @@ func TestRunConvert_HubToSpokeDropsLossyField(t *testing.T) {
 	if out["apiVersion"] != "example.org/v1" {
 		t.Fatalf("expected apiVersion example.org/v1, got %#v", out["apiVersion"])
 	}
-	spec := out["spec"].(map[string]any)
+	spec, ok := out["spec"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected a spec in the output, got %#v", out["spec"])
+	}
 	if spec["storageSize"] != "200" {
 		t.Fatalf("expected spec.storageGB renamed to spec.storageSize, got %#v", spec)
 	}
@@ -86,9 +89,10 @@ func TestRunConvert_FromOverride(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	spec, _ := out["spec"].(map[string]any)
-	if _, renamed := spec["storageSize"]; renamed {
-		t.Fatalf("expected no spec.storageSize: the input had no spec.storageGB to rename, got %#v", spec)
+	if spec, ok := out["spec"].(map[string]any); ok {
+		if _, renamed := spec["storageSize"]; renamed {
+			t.Fatalf("expected no spec.storageSize: the input had no spec.storageGB to rename, got %#v", spec)
+		}
 	}
 	if out["apiVersion"] != "example.org/v1" {
 		t.Fatalf("expected apiVersion example.org/v1, got %#v", out["apiVersion"])

--- a/internal/cli/convert_test.go
+++ b/internal/cli/convert_test.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2026 The declarative-conversion-operator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRunConvert_SpokeToHub(t *testing.T) {
+	out, err := RunConvert(ConvertOptions{
+		XRDPath:    "testdata/xrd.yaml",
+		ConfigPath: "testdata/config.yaml",
+		SamplePath: "testdata/samples/sample1-v1.yaml",
+		To:         "v2",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out["apiVersion"] != "example.org/v2" {
+		t.Fatalf("expected apiVersion to be restamped to the target version, got %#v", out["apiVersion"])
+	}
+	if out["kind"] != "Foo" {
+		t.Fatalf("expected kind to survive the conversion, got %#v", out["kind"])
+	}
+	spec, ok := out["spec"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected a spec in the output, got %#v", out["spec"])
+	}
+	if spec["storageGB"] != "100" {
+		t.Fatalf("expected spec.storageSize to be renamed to spec.storageGB, got %#v", spec)
+	}
+	if _, stillThere := spec["storageSize"]; stillThere {
+		t.Fatalf("expected spec.storageSize not to survive the rename, got %#v", spec)
+	}
+}
+
+func TestRunConvert_HubToSpokeDropsLossyField(t *testing.T) {
+	out, err := RunConvert(ConvertOptions{
+		XRDPath:    "testdata/xrd.yaml",
+		ConfigPath: "testdata/config.yaml",
+		SamplePath: "testdata/samples/sample2-v2.yaml",
+		To:         "v1",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out["apiVersion"] != "example.org/v1" {
+		t.Fatalf("expected apiVersion example.org/v1, got %#v", out["apiVersion"])
+	}
+	spec := out["spec"].(map[string]any)
+	if spec["storageSize"] != "200" {
+		t.Fatalf("expected spec.storageGB renamed to spec.storageSize, got %#v", spec)
+	}
+	if _, present := spec["legacyDebugFlag"]; present {
+		t.Fatalf("expected the acknowledged-lossy Delete rule to drop spec.legacyDebugFlag, got %#v", spec)
+	}
+}
+
+// TestRunConvert_FromOverride pins the --from escape hatch: the sample
+// asserts v1, but converting it as if it were a hub object must take the
+// hub->spoke direction instead.
+func TestRunConvert_FromOverride(t *testing.T) {
+	out, err := RunConvert(ConvertOptions{
+		XRDPath:    "testdata/xrd.yaml",
+		ConfigPath: "testdata/config.yaml",
+		SamplePath: "testdata/samples/sample1-v1.yaml",
+		From:       "v2",
+		To:         "v1",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	spec, _ := out["spec"].(map[string]any)
+	if _, renamed := spec["storageSize"]; renamed {
+		t.Fatalf("expected no spec.storageSize: the input had no spec.storageGB to rename, got %#v", spec)
+	}
+	if out["apiVersion"] != "example.org/v1" {
+		t.Fatalf("expected apiVersion example.org/v1, got %#v", out["apiVersion"])
+	}
+}
+
+func TestRunConvert_CRDConfig(t *testing.T) {
+	out, err := RunConvert(ConvertOptions{
+		CRDPath:    "testdata/crd.yaml",
+		ConfigPath: "testdata/crdconfig.yaml",
+		SamplePath: "testdata/crdsamples/sample1-v1.yaml",
+		To:         "v2",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out["apiVersion"] != "example.org/v2" {
+		t.Fatalf("expected apiVersion example.org/v2, got %#v", out["apiVersion"])
+	}
+}
+
+func TestRunConvert_UnknownTargetVersion(t *testing.T) {
+	_, err := RunConvert(ConvertOptions{
+		XRDPath:    "testdata/xrd.yaml",
+		ConfigPath: "testdata/config.yaml",
+		SamplePath: "testdata/samples/sample1-v1.yaml",
+		To:         "v99",
+	})
+	if err == nil {
+		t.Fatalf("expected an error converting to a version with no compiled plan")
+	}
+}
+
+func TestRunConvert_MultiDocumentSampleIsRejected(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "two.yaml")
+	data, err := os.ReadFile("testdata/samples/sample1-v1.yaml")
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	if err := os.WriteFile(path, append(append([]byte{}, data...), append([]byte("---\n"), data...)...), 0o600); err != nil {
+		t.Fatalf("write temp sample: %v", err)
+	}
+	if _, err := loadSingleSample(path); err == nil {
+		t.Fatalf("expected a multi-document sample to be rejected")
+	}
+}
+
+func TestRunConvert_MissingTo(t *testing.T) {
+	_, err := RunConvert(ConvertOptions{
+		XRDPath:    "testdata/xrd.yaml",
+		ConfigPath: "testdata/config.yaml",
+		SamplePath: "testdata/samples/sample1-v1.yaml",
+	})
+	if err == nil {
+		t.Fatalf("expected an error when --to is missing")
+	}
+}

--- a/internal/cli/failon_test.go
+++ b/internal/cli/failon_test.go
@@ -1,0 +1,157 @@
+/*
+Copyright 2026 The declarative-conversion-operator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"fmt"
+	"testing"
+)
+
+// outcome is one of the report shapes a run can end in, named the way
+// docs/cli.md's exit-code matrix names them so the table below and the
+// documented matrix can be read side by side.
+type outcome string
+
+const (
+	outcomePass            outcome = "pass"
+	outcomeAcknowledged    outcome = "acknowledged loss only"
+	outcomeUnacknowledged  outcome = "unacknowledged loss"
+	outcomeError           outcome = "conversion error"
+	outcomeUnusedRule      outcome = "unused rule coverage"
+	outcomeAckAndUnusedRle outcome = "acknowledged loss and unused rule"
+)
+
+func reportFor(o outcome) *Report {
+	rep := &Report{}
+	rep.Summary.Samples = 1
+	rep.Summary.PathsTested = 1
+	rep.RuleCoverage = []RuleCoverage{{RuleID: "v1:rule[0]:FieldRename", MatchedSamples: 1}}
+	switch o {
+	case outcomePass:
+		rep.Summary.Pass = 1
+	case outcomeAcknowledged:
+		rep.Summary.AcknowledgedLoss = 1
+	case outcomeUnacknowledged:
+		rep.Summary.UnacknowledgedLoss = 1
+	case outcomeError:
+		rep.Summary.Errors = 1
+	case outcomeUnusedRule:
+		rep.Summary.Pass = 1
+		rep.RuleCoverage[0].MatchedSamples = 0
+	case outcomeAckAndUnusedRle:
+		rep.Summary.AcknowledgedLoss = 1
+		rep.RuleCoverage[0].MatchedSamples = 0
+	}
+	return rep
+}
+
+// TestDecideExitCode covers every cell of the --fail-on × outcome ×
+// --strict matrix documented in docs/cli.md. If a cell here changes, that
+// table has to change with it.
+func TestDecideExitCode(t *testing.T) {
+	outcomes := []outcome{
+		outcomePass, outcomeAcknowledged, outcomeUnacknowledged,
+		outcomeError, outcomeUnusedRule, outcomeAckAndUnusedRle,
+	}
+	// want[failOn][strict][outcome]
+	want := map[string]map[bool]map[outcome]int{
+		failOnNone: {
+			false: {
+				outcomePass: ExitOK, outcomeAcknowledged: ExitOK, outcomeUnacknowledged: ExitOK,
+				outcomeError: ExitOK, outcomeUnusedRule: ExitOK, outcomeAckAndUnusedRle: ExitOK,
+			},
+			// --fail-on none wins outright: it is the explicit "report,
+			// never gate" switch, so --strict cannot resurrect a failure.
+			true: {
+				outcomePass: ExitOK, outcomeAcknowledged: ExitOK, outcomeUnacknowledged: ExitOK,
+				outcomeError: ExitOK, outcomeUnusedRule: ExitOK, outcomeAckAndUnusedRle: ExitOK,
+			},
+		},
+		failOnWarn: {
+			false: {
+				outcomePass: ExitOK, outcomeAcknowledged: ExitOK, outcomeUnacknowledged: ExitTestFailure,
+				outcomeError: ExitTestFailure, outcomeUnusedRule: ExitTestFailure, outcomeAckAndUnusedRle: ExitTestFailure,
+			},
+			true: {
+				outcomePass: ExitOK, outcomeAcknowledged: ExitOK, outcomeUnacknowledged: ExitTestFailure,
+				outcomeError: ExitTestFailure, outcomeUnusedRule: ExitTestFailure, outcomeAckAndUnusedRle: ExitTestFailure,
+			},
+		},
+		failOnLoss: {
+			// The default: an acknowledged loss is a decision already
+			// made, and a coverage gap is only a warning, so neither
+			// fails on its own.
+			false: {
+				outcomePass: ExitOK, outcomeAcknowledged: ExitOK, outcomeUnacknowledged: ExitTestFailure,
+				outcomeError: ExitTestFailure, outcomeUnusedRule: ExitOK, outcomeAckAndUnusedRle: ExitOK,
+			},
+			// --strict escalates coverage gaps to failures, matching what
+			// --fail-on warn does for the same check.
+			true: {
+				outcomePass: ExitOK, outcomeAcknowledged: ExitOK, outcomeUnacknowledged: ExitTestFailure,
+				outcomeError: ExitTestFailure, outcomeUnusedRule: ExitTestFailure, outcomeAckAndUnusedRle: ExitTestFailure,
+			},
+		},
+	}
+
+	for _, failOn := range []string{failOnNone, failOnWarn, failOnLoss} {
+		for _, strict := range []bool{false, true} {
+			for _, o := range outcomes {
+				name := fmt.Sprintf("fail-on=%s/strict=%v/%s", failOn, strict, o)
+				t.Run(name, func(t *testing.T) {
+					got := decideExitCode(reportFor(o), failOn, strict)
+					if got != want[failOn][strict][o] {
+						t.Fatalf("decideExitCode = %d, want %d", got, want[failOn][strict][o])
+					}
+				})
+			}
+		}
+	}
+}
+
+func TestTestCmd_RejectsInvalidFailOn(t *testing.T) {
+	cmd := newTestCmd()
+	cmd.SetArgs([]string{
+		"--config", "testdata/config.yaml", "--xrd", "testdata/xrd.yaml",
+		"--samples", "testdata/samples", "--fail-on", "everything",
+	})
+	cmd.SilenceUsage, cmd.SilenceErrors = true, true
+	if err := cmd.Execute(); err == nil {
+		t.Fatalf("expected an invalid --fail-on value to be a usage error")
+	}
+}
+
+func TestTestCmd_AcceptsEveryFailOnValue(t *testing.T) {
+	for _, v := range []string{failOnNone, failOnWarn, failOnLoss} {
+		t.Run(v, func(t *testing.T) {
+			cmd := newTestCmd()
+			cmd.SetOut(discardWriter{})
+			cmd.SetArgs([]string{
+				"--config", "testdata/config.yaml", "--xrd", "testdata/xrd.yaml",
+				"--samples", "testdata/samples", "--fail-on", v,
+			})
+			cmd.SilenceUsage, cmd.SilenceErrors = true, true
+			if err := cmd.Execute(); err != nil {
+				t.Fatalf("unexpected error for --fail-on %s: %v", v, err)
+			}
+		})
+	}
+}
+
+type discardWriter struct{}
+
+func (discardWriter) Write(p []byte) (int, error) { return len(p), nil }

--- a/internal/cli/live.go
+++ b/internal/cli/live.go
@@ -22,11 +22,16 @@ import (
 	"strings"
 
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/tools/clientcmd"
+
+	teraskyv1alpha1 "github.com/terasky-oss/declarative-conversion-operator/api/v1alpha1"
+	"github.com/terasky-oss/declarative-conversion-operator/pkg/xrdadapter"
 )
 
 // KubeOptions configures how `test --live` reaches a cluster. It follows
@@ -137,6 +142,78 @@ func fetchLiveSamplesByGVR(ctx context.Context, dyn dynamic.Interface, gvr schem
 		}
 	}
 	return samples, nil
+}
+
+// The GroupVersionResources `convctl diff --live` addresses. Both target
+// schemas are cluster-scoped, and so are XRDConversionConfig and
+// CRDConversionConfig, so every lookup below is by name alone.
+var (
+	xrdGVR = xrdadapter.GroupVersionKind.GroupVersion().WithResource("compositeresourcedefinitions")
+	crdGVR = schema.GroupVersionResource{Group: extv1.GroupName, Version: "v1", Resource: "customresourcedefinitions"}
+
+	xrdConversionConfigGVR = teraskyv1alpha1.GroupVersion.WithResource("xrdconversionconfigs")
+	crdConversionConfigGVR = teraskyv1alpha1.GroupVersion.WithResource("crdconversionconfigs")
+)
+
+// FetchLiveXRD reads the target XRD straight from the cluster, so a diff
+// against live state uses the schema the cluster actually has rather than
+// whatever local copy happens to be lying around.
+func FetchLiveXRD(ctx context.Context, dyn dynamic.Interface, name string) (*unstructured.Unstructured, error) {
+	obj, err := dyn.Resource(xrdGVR).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("getting XRD %q: %w", name, err)
+	}
+	return obj, nil
+}
+
+// FetchLiveCRD is FetchLiveXRD's sibling for a native CRD, decoded into the
+// typed apiextensions.k8s.io/v1 shape pkg/crdadapter consumes.
+func FetchLiveCRD(ctx context.Context, dyn dynamic.Interface, name string) (*extv1.CustomResourceDefinition, error) {
+	obj, err := dyn.Resource(crdGVR).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("getting CRD %q: %w", name, err)
+	}
+	var crd extv1.CustomResourceDefinition
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, &crd); err != nil {
+		return nil, fmt.Errorf("decoding CRD %q: %w", name, err)
+	}
+	return &crd, nil
+}
+
+// FetchLiveXRDConversionConfig reads the XRDConversionConfig currently
+// applied under name. A missing config is not an error — "nothing is
+// configured yet" is exactly the state a diff is most often run against —
+// so it returns (nil, nil) and lets the caller decide what to compare with.
+func FetchLiveXRDConversionConfig(ctx context.Context, dyn dynamic.Interface, name string) (*teraskyv1alpha1.XRDConversionConfig, error) {
+	obj, err := dyn.Resource(xrdConversionConfigGVR).Get(ctx, name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("getting XRDConversionConfig %q: %w", name, err)
+	}
+	var cfg teraskyv1alpha1.XRDConversionConfig
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, &cfg); err != nil {
+		return nil, fmt.Errorf("decoding XRDConversionConfig %q: %w", name, err)
+	}
+	return &cfg, nil
+}
+
+// FetchLiveCRDConversionConfig is FetchLiveXRDConversionConfig's sibling
+// for CRDConversionConfig, with the same "missing is not an error" contract.
+func FetchLiveCRDConversionConfig(ctx context.Context, dyn dynamic.Interface, name string) (*teraskyv1alpha1.CRDConversionConfig, error) {
+	obj, err := dyn.Resource(crdConversionConfigGVR).Get(ctx, name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("getting CRDConversionConfig %q: %w", name, err)
+	}
+	var cfg teraskyv1alpha1.CRDConversionConfig
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, &cfg); err != nil {
+		return nil, fmt.Errorf("decoding CRDConversionConfig %q: %w", name, err)
+	}
+	return &cfg, nil
 }
 
 func objectLabel(obj *unstructured.Unstructured) string {

--- a/internal/cli/patchpreview.go
+++ b/internal/cli/patchpreview.go
@@ -1,0 +1,205 @@
+/*
+Copyright 2026 The declarative-conversion-operator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"encoding/base64"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	sigsyaml "sigs.k8s.io/yaml"
+
+	"github.com/terasky-oss/declarative-conversion-operator/internal/conversionpatch"
+)
+
+// PatchPreviewOptions configures RunPatchPreview.
+type PatchPreviewOptions struct {
+	ConfigPath string
+	// XRDPath and CRDPath are optional: supplying one runs the same schema
+	// validation `convctl analyze` does before rendering the patch, so a
+	// config that could never be applied doesn't get a preview of being
+	// applied.
+	XRDPath string
+	CRDPath string
+
+	ServiceName      string
+	ServiceNamespace string
+	// Path defaults to "/convert/<target name>", the route the operator
+	// derives from the config's target.
+	Path string
+	Port int32
+	// CABundle is accepted either base64-encoded (as it appears in a CRD's
+	// YAML) or as raw PEM, which is detected and encoded.
+	CABundle string
+	PlanHash string
+}
+
+// RunPatchPreview renders the exact server-side-apply object the operator
+// would send to the target XRD or CRD. It is strictly offline: no client is
+// ever constructed, so it cannot touch a cluster even by accident.
+func RunPatchPreview(opts PatchPreviewOptions) ([]byte, error) {
+	if opts.ServiceName == "" || opts.ServiceNamespace == "" {
+		return nil, fmt.Errorf("--service-name and --service-namespace are required: patch-preview never contacts a cluster to look them up")
+	}
+	if opts.CABundle == "" {
+		return nil, fmt.Errorf("--ca-bundle is required: the patch the operator applies always carries one")
+	}
+	caBundle := normalizeCABundle(opts.CABundle)
+	port := opts.Port
+	if port == 0 {
+		port = 443
+	}
+
+	kind, err := PeekConfigKind(opts.ConfigPath)
+	if err != nil {
+		return nil, err
+	}
+	if kind == "CRDConversionConfig" {
+		cfg, err := LoadCRDConfig(opts.ConfigPath)
+		if err != nil {
+			return nil, err
+		}
+		if opts.XRDPath != "" {
+			return nil, fmt.Errorf("%s is a CRDConversionConfig; pass its target schema with --crd, not --xrd", opts.ConfigPath)
+		}
+		if opts.CRDPath != "" {
+			crd, err := LoadCRD(opts.CRDPath)
+			if err != nil {
+				return nil, err
+			}
+			report, _, err := runAnalyzeCRD(crd, cfg)
+			if err != nil {
+				return nil, err
+			}
+			if report.HasErrors() {
+				return nil, fmt.Errorf("configuration is invalid against the CRD schema, the operator would never apply this patch:%s", summarizeSpokeErrors(report))
+			}
+		}
+		params := conversionpatch.Params{
+			TargetName: cfg.Spec.TargetCRD.Name, ConfigName: cfg.Name, PlanHash: opts.PlanHash,
+			ServiceName: opts.ServiceName, ServiceNamespace: opts.ServiceNamespace,
+			Path: orDefault(opts.Path, "/convert/"+cfg.Spec.TargetCRD.Name), Port: port,
+			CABundle: caBundle, ReviewVersions: reviewVersionsOrDefault(cfg.Spec.ConversionReviewVersions),
+		}
+		patch, err := conversionpatch.BuildCRDConversionPatch(params)
+		if err != nil {
+			return nil, err
+		}
+		return marshalPatch(patch)
+	}
+
+	cfg, err := LoadConfig(opts.ConfigPath)
+	if err != nil {
+		return nil, err
+	}
+	if opts.CRDPath != "" {
+		return nil, fmt.Errorf("%s is an XRDConversionConfig; pass its target schema with --xrd, not --crd", opts.ConfigPath)
+	}
+	if opts.XRDPath != "" {
+		xrd, err := LoadXRD(opts.XRDPath)
+		if err != nil {
+			return nil, err
+		}
+		report, _, err := runAnalyze(xrd, cfg)
+		if err != nil {
+			return nil, err
+		}
+		if report.HasErrors() {
+			return nil, fmt.Errorf("configuration is invalid against the XRD schema, the operator would never apply this patch:%s", summarizeSpokeErrors(report))
+		}
+	}
+	patch := conversionpatch.BuildXRDConversionPatch(conversionpatch.Params{
+		TargetName: cfg.Spec.TargetXRD.Name, ConfigName: cfg.Name, PlanHash: opts.PlanHash,
+		ServiceName: opts.ServiceName, ServiceNamespace: opts.ServiceNamespace,
+		Path: orDefault(opts.Path, "/convert/"+cfg.Spec.TargetXRD.Name), Port: port,
+		CABundle: caBundle, ReviewVersions: reviewVersionsOrDefault(cfg.Spec.ConversionReviewVersions),
+	})
+	return marshalPatch(patch.Object)
+}
+
+func marshalPatch(v any) ([]byte, error) {
+	data, err := sigsyaml.Marshal(v)
+	if err != nil {
+		return nil, fmt.Errorf("rendering YAML: %w", err)
+	}
+	return data, nil
+}
+
+// normalizeCABundle accepts the bundle either already base64-encoded or as
+// raw PEM. PEM's "-----BEGIN" armor isn't in the standard base64 alphabet,
+// so a successful decode is a reliable signal the input was already
+// encoded.
+func normalizeCABundle(v string) string {
+	if _, err := base64.StdEncoding.DecodeString(v); err == nil {
+		return v
+	}
+	return base64.StdEncoding.EncodeToString([]byte(v))
+}
+
+func reviewVersionsOrDefault(vs []string) []string {
+	if len(vs) == 0 {
+		return []string{"v1"}
+	}
+	return vs
+}
+
+func orDefault(v, fallback string) string {
+	if v == "" {
+		return fallback
+	}
+	return v
+}
+
+func newPatchPreviewCmd() *cobra.Command {
+	var opts PatchPreviewOptions
+	cmd := &cobra.Command{
+		Use:   "patch-preview",
+		Short: "Print the server-side-apply patch the operator would send to the target",
+		Long: `Render the exact object the operator server-side-applies onto the target XRD or
+CRD to point its spec.conversion at a webhook server — built by the same code the
+controllers call, not a reimplementation that could drift from it.
+
+This is a fully offline dry run. No Kubernetes client is ever constructed, which
+is why the service coordinates and CA bundle are flags rather than cluster
+lookups. Supply --xrd or --crd to additionally validate the config against its
+schema first, so a config the operator would refuse to apply doesn't get a
+preview of being applied.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			data, err := RunPatchPreview(opts)
+			if err != nil {
+				return err
+			}
+			_, err = cmd.OutOrStdout().Write(data)
+			return err
+		},
+	}
+	cmd.Flags().StringVarP(&opts.ConfigPath, "config", "c", "", "Path to an XRDConversionConfig or CRDConversionConfig YAML file (required)")
+	cmd.Flags().StringVarP(&opts.XRDPath, "xrd", "x", "", "Path to an XRD YAML file (optional; validates the config against its schema first)")
+	cmd.Flags().StringVar(&opts.CRDPath, "crd", "", "Path to a CRD YAML file (optional; validates the config against its schema first)")
+	cmd.Flags().StringVar(&opts.ServiceName, "service-name", "", "Name of the webhook server Service (required)")
+	cmd.Flags().StringVar(&opts.ServiceNamespace, "service-namespace", "", "Namespace of the webhook server Service (required)")
+	cmd.Flags().StringVar(&opts.Path, "path", "", "Webhook path (default: /convert/<target name>)")
+	cmd.Flags().Int32Var(&opts.Port, "port", 443, "Webhook Service port")
+	cmd.Flags().StringVar(&opts.CABundle, "ca-bundle", "", "CA bundle, base64-encoded or raw PEM (required)")
+	cmd.Flags().StringVar(&opts.PlanHash, "plan-hash", "", "Value for the plan-hash annotation (default: empty, as it is before the first successful validation)")
+	_ = cmd.MarkFlagRequired("config")
+	_ = cmd.MarkFlagRequired("service-name")
+	_ = cmd.MarkFlagRequired("service-namespace")
+	_ = cmd.MarkFlagRequired("ca-bundle")
+	cmd.MarkFlagsMutuallyExclusive("xrd", "crd")
+	return cmd
+}

--- a/internal/cli/patchpreview.go
+++ b/internal/cli/patchpreview.go
@@ -19,6 +19,7 @@ package cli
 import (
 	"encoding/base64"
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 	sigsyaml "sigs.k8s.io/yaml"
@@ -144,8 +145,12 @@ func marshalPatch(v any) ([]byte, error) {
 // so a successful decode is a reliable signal the input was already
 // encoded.
 func normalizeCABundle(v string) string {
-	if _, err := base64.StdEncoding.DecodeString(v); err == nil {
-		return v
+	if strings.Contains(v, "-----BEGIN") {
+		return base64.StdEncoding.EncodeToString([]byte(v))
+	}
+	compact := strings.Join(strings.Fields(v), "")
+	if _, err := base64.StdEncoding.DecodeString(compact); err == nil {
+		return compact
 	}
 	return base64.StdEncoding.EncodeToString([]byte(v))
 }

--- a/internal/cli/patchpreview_test.go
+++ b/internal/cli/patchpreview_test.go
@@ -1,0 +1,176 @@
+/*
+Copyright 2026 The declarative-conversion-operator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	sigsyaml "sigs.k8s.io/yaml"
+)
+
+func basePreviewOptions() PatchPreviewOptions {
+	return PatchPreviewOptions{
+		ConfigPath:       "testdata/config.yaml",
+		ServiceName:      "prod-webhook-server",
+		ServiceNamespace: "conversion-system",
+		CABundle:         base64.StdEncoding.EncodeToString([]byte("PEM")),
+	}
+}
+
+func decodePreview(t *testing.T, data []byte) map[string]any {
+	t.Helper()
+	var out map[string]any
+	if err := sigsyaml.Unmarshal(data, &out); err != nil {
+		t.Fatalf("preview is not valid YAML: %v\n%s", err, data)
+	}
+	return out
+}
+
+func TestRunPatchPreview_XRDDefaults(t *testing.T) {
+	data, err := RunPatchPreview(basePreviewOptions())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	obj := decodePreview(t, data)
+
+	if obj["apiVersion"] != "apiextensions.crossplane.io/v2" || obj["kind"] != "CompositeResourceDefinition" {
+		t.Fatalf("unexpected target type: %v/%v", obj["apiVersion"], obj["kind"])
+	}
+	name, _, _ := unstructured.NestedString(obj, "metadata", "name")
+	if name != "xfoos.example.org" {
+		t.Fatalf("expected the patch to target the config's XRD, got %q", name)
+	}
+	path, _, _ := unstructured.NestedString(obj, "spec", "conversion", "webhook", "clientConfig", "service", "path")
+	if path != "/convert/xfoos.example.org" {
+		t.Fatalf("expected the path to default to /convert/<target>, got %q", path)
+	}
+	port, _, _ := unstructured.NestedFloat64(obj, "spec", "conversion", "webhook", "clientConfig", "service", "port")
+	if port != 443 {
+		t.Fatalf("expected the port to default to 443, got %v", port)
+	}
+	versions, _, _ := unstructured.NestedStringSlice(obj, "spec", "conversion", "webhook", "conversionReviewVersions")
+	if len(versions) != 1 || versions[0] != "v1" {
+		t.Fatalf("expected conversionReviewVersions to default to [v1], got %v", versions)
+	}
+}
+
+func TestRunPatchPreview_ExplicitOverrides(t *testing.T) {
+	opts := basePreviewOptions()
+	opts.Path = "/custom/route"
+	opts.Port = 8443
+	opts.PlanHash = "sha256:deadbeef"
+
+	obj := decodePreview(t, mustPreview(t, opts))
+	path, _, _ := unstructured.NestedString(obj, "spec", "conversion", "webhook", "clientConfig", "service", "path")
+	if path != "/custom/route" {
+		t.Fatalf("path = %q", path)
+	}
+	port, _, _ := unstructured.NestedFloat64(obj, "spec", "conversion", "webhook", "clientConfig", "service", "port")
+	if port != 8443 {
+		t.Fatalf("port = %v", port)
+	}
+	hash, _, _ := unstructured.NestedString(obj, "metadata", "annotations", "conversion.terasky.com/plan-hash")
+	if hash != "sha256:deadbeef" {
+		t.Fatalf("plan-hash annotation = %q", hash)
+	}
+}
+
+// TestRunPatchPreview_RawPEMCABundle covers the convenience the flag
+// documents: a raw PEM bundle is encoded on the way in, while an
+// already-encoded one is passed through untouched.
+func TestRunPatchPreview_RawPEMCABundle(t *testing.T) {
+	raw := "-----BEGIN CERTIFICATE-----\nabc\n-----END CERTIFICATE-----"
+	opts := basePreviewOptions()
+	opts.CABundle = raw
+
+	obj := decodePreview(t, mustPreview(t, opts))
+	got, _, _ := unstructured.NestedString(obj, "spec", "conversion", "webhook", "clientConfig", "caBundle")
+	decoded, err := base64.StdEncoding.DecodeString(got)
+	if err != nil {
+		t.Fatalf("expected a base64 caBundle, got %q: %v", got, err)
+	}
+	if string(decoded) != raw {
+		t.Fatalf("decoded caBundle = %q, want the raw PEM back", decoded)
+	}
+}
+
+func TestRunPatchPreview_ValidatesAgainstSchemaWhenGiven(t *testing.T) {
+	opts := basePreviewOptions()
+	opts.XRDPath = "testdata/xrd.yaml"
+	if _, err := RunPatchPreview(opts); err != nil {
+		t.Fatalf("a valid config should preview cleanly: %v", err)
+	}
+
+	// The same schema with the rename rule dropped leaves fields
+	// uncovered, which the operator would refuse to apply — so should
+	// this.
+	opts.ConfigPath = "testdata/config-norename.yaml"
+	if _, err := RunPatchPreview(opts); err == nil {
+		t.Fatalf("expected a config that fails schema validation to be refused a preview")
+	}
+}
+
+func TestRunPatchPreview_CRDConfig(t *testing.T) {
+	opts := basePreviewOptions()
+	opts.ConfigPath = "testdata/crdconfig.yaml"
+	opts.CRDPath = "testdata/crd.yaml"
+
+	obj := decodePreview(t, mustPreview(t, opts))
+	if obj["apiVersion"] != "apiextensions.k8s.io/v1" || obj["kind"] != "CustomResourceDefinition" {
+		t.Fatalf("unexpected target type: %v/%v", obj["apiVersion"], obj["kind"])
+	}
+	strategy, _, _ := unstructured.NestedString(obj, "spec", "conversion", "strategy")
+	if strategy != "Webhook" {
+		t.Fatalf("strategy = %q", strategy)
+	}
+}
+
+func TestRunPatchPreview_RequiredFlags(t *testing.T) {
+	noService := basePreviewOptions()
+	noService.ServiceName = ""
+	noNamespace := basePreviewOptions()
+	noNamespace.ServiceNamespace = ""
+	noCA := basePreviewOptions()
+	noCA.CABundle = ""
+	wrongSchemaFlag := basePreviewOptions()
+	wrongSchemaFlag.CRDPath = "testdata/crd.yaml"
+
+	cases := map[string]PatchPreviewOptions{
+		"missing service name":      noService,
+		"missing service namespace": noNamespace,
+		"missing ca bundle":         noCA,
+		"crd flag on an xrd config": wrongSchemaFlag,
+	}
+	for name, opts := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := RunPatchPreview(opts); err == nil {
+				t.Fatalf("expected an error for %s", name)
+			}
+		})
+	}
+}
+
+func mustPreview(t *testing.T, opts PatchPreviewOptions) []byte {
+	t.Helper()
+	data, err := RunPatchPreview(opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	return data
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -159,9 +159,10 @@ are lossy in which direction, and whether every schema field is covered.`,
 func newTestCmd() *cobra.Command {
 	var (
 		xrdPath, crdPath, configPath, samplesDir, output, failOn, outputFile string
-		skipIdentity, strict, live                                           bool
+		skipIdentity, strict, live, quiet                                    bool
 		versionPairs                                                         []string
 		kubeconfig, kubeContext                                              string
+		concurrency                                                          int
 	)
 	cmd := &cobra.Command{
 		Use:   "test",
@@ -184,7 +185,11 @@ target resource — no write access, and no access to the operator's own CRDs.
 
 --output selects table (default), json, or junit (for CI test-result reporters).
 --output-file writes the full report to a path instead of stdout; a short
-pass/loss/fail/error summary still prints to stdout either way.`,
+pass/loss/fail/error summary still prints to stdout either way.
+
+Samples are tested in parallel (--concurrency, default one worker per CPU) with
+progress on stderr (--quiet to silence it). The report is identical either way:
+results are collected by sample index, never by completion order.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			switch output {
 			case "table", "json", "junit":
@@ -200,6 +205,7 @@ pass/loss/fail/error summary still prints to stdout either way.`,
 				XRDPath: xrdPath, CRDPath: crdPath, ConfigPath: configPath, SamplesDir: samplesDir,
 				SkipIdentity: skipIdentity, RestrictVersionPairs: versionPairs,
 				Live: live, Kubeconfig: kubeconfig, KubeContext: kubeContext,
+				Concurrency: concurrency, Quiet: quiet,
 			})
 			if err != nil {
 				return err
@@ -245,6 +251,8 @@ pass/loss/fail/error summary still prints to stdout either way.`,
 	cmd.Flags().BoolVar(&strict, "strict", false, "Escalate warnings (e.g. rule-coverage gaps) to failures")
 	cmd.Flags().StringVar(&failOn, "fail-on", failOnLoss, "Exit-code threshold: none|warn|loss")
 	cmd.Flags().StringSliceVar(&versionPairs, "version-pair", nil, "Restrict testing to these version(s), repeatable")
+	cmd.Flags().IntVar(&concurrency, "concurrency", 0, "Number of samples to test in parallel (default: one per available CPU)")
+	cmd.Flags().BoolVar(&quiet, "quiet", false, "Suppress the progress line written to stderr")
 	_ = cmd.MarkFlagRequired("config")
 	cmd.MarkFlagsOneRequired("xrd", "crd")
 	cmd.MarkFlagsMutuallyExclusive("xrd", "crd")

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -51,7 +51,7 @@ cluster. Every command works against either resource type:
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
-	root.AddCommand(newValidateCmd(), newAnalyzeCmd(), newTestCmd(), newDiffCmd(), newConvertCmd(), newVersionCmd())
+	root.AddCommand(newValidateCmd(), newAnalyzeCmd(), newTestCmd(), newDiffCmd(), newConvertCmd(), newSuggestCmd(), newVersionCmd())
 
 	if err := root.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, "error:", err)

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -51,7 +51,10 @@ cluster. Every command works against either resource type:
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
-	root.AddCommand(newValidateCmd(), newAnalyzeCmd(), newTestCmd(), newDiffCmd(), newConvertCmd(), newSuggestCmd(), newVersionCmd())
+	root.AddCommand(
+		newValidateCmd(), newAnalyzeCmd(), newTestCmd(), newDiffCmd(),
+		newConvertCmd(), newSuggestCmd(), newPatchPreviewCmd(), newVersionCmd(),
+	)
 
 	if err := root.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, "error:", err)

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -51,7 +51,7 @@ cluster. Every command works against either resource type:
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
-	root.AddCommand(newValidateCmd(), newAnalyzeCmd(), newTestCmd(), newDiffCmd(), newVersionCmd())
+	root.AddCommand(newValidateCmd(), newAnalyzeCmd(), newTestCmd(), newDiffCmd(), newConvertCmd(), newVersionCmd())
 
 	if err := root.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, "error:", err)

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -191,6 +191,11 @@ pass/loss/fail/error summary still prints to stdout either way.`,
 			default:
 				return fmt.Errorf("invalid --output value %q (want table, json, or junit)", output)
 			}
+			switch failOn {
+			case failOnNone, failOnWarn, failOnLoss:
+			default:
+				return fmt.Errorf("invalid --fail-on value %q (want %s, %s, or %s)", failOn, failOnNone, failOnWarn, failOnLoss)
+			}
 			rep, err := RunTest(TestOptions{
 				XRDPath: xrdPath, CRDPath: crdPath, ConfigPath: configPath, SamplesDir: samplesDir,
 				SkipIdentity: skipIdentity, RestrictVersionPairs: versionPairs,
@@ -238,7 +243,7 @@ pass/loss/fail/error summary still prints to stdout either way.`,
 	cmd.Flags().StringVar(&outputFile, "output-file", "", "Write the full report to this file instead of stdout; a short summary still prints to stdout")
 	cmd.Flags().BoolVar(&skipIdentity, "skip-identity", false, "Skip trivial same-version passthrough checks")
 	cmd.Flags().BoolVar(&strict, "strict", false, "Escalate warnings (e.g. rule-coverage gaps) to failures")
-	cmd.Flags().StringVar(&failOn, "fail-on", "loss", "Exit-code threshold: none|warn|loss")
+	cmd.Flags().StringVar(&failOn, "fail-on", failOnLoss, "Exit-code threshold: none|warn|loss")
 	cmd.Flags().StringSliceVar(&versionPairs, "version-pair", nil, "Restrict testing to these version(s), repeatable")
 	_ = cmd.MarkFlagRequired("config")
 	cmd.MarkFlagsOneRequired("xrd", "crd")
@@ -306,14 +311,31 @@ drops straight into a CI gate.`,
 	return cmd
 }
 
+// The accepted --fail-on thresholds, in increasing order of tolerance. See
+// docs/cli.md for the full threshold × outcome exit-code matrix.
+const (
+	// failOnNone reports results but never fails the process.
+	failOnNone = "none"
+	// failOnWarn fails on warnings too — today, a declared rule no sample
+	// ever exercised.
+	failOnWarn = "warn"
+	// failOnLoss (the default) fails only on an unacknowledged loss or a
+	// conversion error. An acknowledged loss is a decision the config
+	// author already made explicitly, so it never fails here.
+	failOnLoss = "loss"
+)
+
 func decideExitCode(rep *Report, failOn string, strict bool) int {
-	if failOn == "none" {
+	if failOn == failOnNone {
 		return ExitOK
 	}
 	if rep.Summary.Errors > 0 || rep.Summary.UnacknowledgedLoss > 0 {
 		return ExitTestFailure
 	}
-	if failOn == "warn" || strict {
+	// --strict escalates coverage gaps exactly the way --fail-on warn
+	// does; the two are interchangeable for this check, and either one
+	// alone is enough to trip it.
+	if failOn == failOnWarn || strict {
 		for _, rc := range rep.RuleCoverage {
 			if rc.MatchedSamples == 0 {
 				return ExitTestFailure

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -51,7 +51,7 @@ cluster. Every command works against either resource type:
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
-	root.AddCommand(newValidateCmd(), newAnalyzeCmd(), newTestCmd(), newVersionCmd())
+	root.AddCommand(newValidateCmd(), newAnalyzeCmd(), newTestCmd(), newDiffCmd(), newVersionCmd())
 
 	if err := root.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, "error:", err)
@@ -245,6 +245,64 @@ pass/loss/fail/error summary still prints to stdout either way.`,
 	cmd.MarkFlagsMutuallyExclusive("xrd", "crd")
 	cmd.MarkFlagsOneRequired("samples", "live")
 	cmd.MarkFlagsMutuallyExclusive("samples", "live")
+	return cmd
+}
+
+func newDiffCmd() *cobra.Command {
+	var (
+		configPaths                                       []string
+		xrdPath, crdPath, output, kubeconfig, kubeContext string
+		live                                              bool
+	)
+	cmd := &cobra.Command{
+		Use:   "diff",
+		Short: "Compare coverage, rule claims, and lossiness between two conversion configs",
+		Long: `Analyze two conversion configs against the same schema and report what changed
+between them: which hub/spoke fields go from covered to uncovered (or back),
+which rules claim which paths, which directions flip between lossless and lossy,
+and which errors and warnings appear or disappear.
+
+Pass --config twice to compare two local files. Pass it once with --live to
+compare against the cluster instead: the live XRD/CRD supplies the schema, and
+the ConversionConfig of the same name supplies the other side. If the cluster
+has no such config yet, the comparison runs against an empty rule set for the
+same spokes — "what would applying this claim?" rather than an error.
+
+Exits 0 when the two sides are equivalent and 1 when any delta is found, so it
+drops straight into a CI gate.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			switch output {
+			case "table", "json":
+			default:
+				return fmt.Errorf("invalid --output value %q (want table or json)", output)
+			}
+			out, err := RunDiff(DiffOptions{
+				ConfigPaths: configPaths, XRDPath: xrdPath, CRDPath: crdPath,
+				Live: live, Kubeconfig: kubeconfig, KubeContext: kubeContext,
+			})
+			if err != nil {
+				return err
+			}
+			if output == "table" {
+				out.WriteTable(cmd.OutOrStdout())
+			} else if err := writeJSON(cmd, out); err != nil {
+				return err
+			}
+			if out.HasDeltas {
+				exitCode = ExitTestFailure
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringArrayVarP(&configPaths, "config", "c", nil, "Path to a conversion config YAML file; pass twice to compare two files, or once with --live")
+	cmd.Flags().StringVarP(&xrdPath, "xrd", "x", "", "Path to an XRD YAML file (required for two-file mode against XRDConversionConfigs)")
+	cmd.Flags().StringVar(&crdPath, "crd", "", "Path to a CRD YAML file (required for two-file mode against CRDConversionConfigs)")
+	cmd.Flags().BoolVar(&live, "live", false, "Compare the single --config against the cluster's live schema and applied config")
+	cmd.Flags().StringVar(&kubeconfig, "kubeconfig", "", "Path to a kubeconfig file (default: $KUBECONFIG, then ~/.kube/config); only used with --live")
+	cmd.Flags().StringVar(&kubeContext, "context", "", "Kubeconfig context to use (default: the kubeconfig's current-context); only used with --live")
+	cmd.Flags().StringVarP(&output, "output", "o", "json", "Output format: json|table")
+	_ = cmd.MarkFlagRequired("config")
+	cmd.MarkFlagsMutuallyExclusive("xrd", "crd")
 	return cmd
 }
 

--- a/internal/cli/suggest.go
+++ b/internal/cli/suggest.go
@@ -1,0 +1,348 @@
+/*
+Copyright 2026 The declarative-conversion-operator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"unicode"
+
+	"github.com/spf13/cobra"
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	sigsyaml "sigs.k8s.io/yaml"
+
+	teraskyv1alpha1 "github.com/terasky-oss/declarative-conversion-operator/api/v1alpha1"
+	"github.com/terasky-oss/declarative-conversion-operator/pkg/engine"
+)
+
+// SuggestOutput is a set of proposed rules, shaped exactly like the
+// `spec.spokes` stanza of a conversion config so it can be pasted straight
+// in after review.
+type SuggestOutput struct {
+	Spokes []teraskyv1alpha1.SpokeVersionRules `json:"spokes"`
+}
+
+// suggestSimilarityThreshold is how alike two field names must be, after
+// normalization, before a rename is worth proposing. Deliberately
+// permissive: a wrong suggestion costs a reviewer one deleted line, while a
+// missed one costs them a manual schema comparison.
+const suggestSimilarityThreshold = 0.6
+
+// RunSuggest analyzes the config and proposes FieldRename and TypeCoerce
+// rules for the hub and spoke fields it left uncovered. Suggestions are
+// heuristic by construction — the engine can prove a mapping is lossless,
+// but nothing can prove two differently-named fields were meant to be the
+// same one — so the output is a starting point for review, never something
+// to apply unread.
+func RunSuggest(xrdPath, crdPath, configPath string) (*SuggestOutput, error) {
+	kind, err := PeekConfigKind(configPath)
+	if err != nil {
+		return nil, err
+	}
+	if kind == "CRDConversionConfig" {
+		if crdPath == "" {
+			return nil, fmt.Errorf("%s is a CRDConversionConfig; pass its target schema with --crd, not --xrd", configPath)
+		}
+		crd, err := LoadCRD(crdPath)
+		if err != nil {
+			return nil, err
+		}
+		cfg, err := LoadCRDConfig(configPath)
+		if err != nil {
+			return nil, err
+		}
+		report, versions, err := runAnalyzeCRD(crd, cfg)
+		if err != nil {
+			return nil, err
+		}
+		return buildSuggestions(cfg.Spec.HubVersion, versions, report), nil
+	}
+
+	if xrdPath == "" {
+		return nil, fmt.Errorf("%s is an XRDConversionConfig; pass its target schema with --xrd, not --crd", configPath)
+	}
+	xrd, err := LoadXRD(xrdPath)
+	if err != nil {
+		return nil, err
+	}
+	cfg, err := LoadConfig(configPath)
+	if err != nil {
+		return nil, err
+	}
+	report, versions, err := runAnalyze(xrd, cfg)
+	if err != nil {
+		return nil, err
+	}
+	return buildSuggestions(cfg.Spec.HubVersion, versions, report), nil
+}
+
+func buildSuggestions(hubVersion string, versions []engine.VersionSchema, report engine.AnalyzeReport) *SuggestOutput {
+	schemas := map[string]*extv1.JSONSchemaProps{}
+	for _, v := range versions {
+		schemas[v.Name] = v.Schema
+	}
+	hubLeaves := leafIndex(schemas[hubVersion])
+
+	out := &SuggestOutput{}
+	for _, sr := range report.SpokeReports {
+		rules := suggestSpokeRules(sr, hubLeaves, leafIndex(schemas[sr.Version]))
+		if len(rules) == 0 {
+			continue
+		}
+		out.Spokes = append(out.Spokes, teraskyv1alpha1.SpokeVersionRules{Version: sr.Version, Rules: rules})
+	}
+	return out
+}
+
+func leafIndex(schema *extv1.JSONSchemaProps) map[string]engine.LeafField {
+	out := map[string]engine.LeafField{}
+	for _, l := range engine.FlattenSchema(schema) {
+		out[l.Path.String()] = l
+	}
+	return out
+}
+
+// suggestSpokeRules pairs one spoke's uncovered hub fields with its
+// uncovered spoke fields. Type coercions are matched first, since a field
+// that kept its path and only changed type is unambiguous; whatever is left
+// then competes for rename pairings by name similarity.
+func suggestSpokeRules(sr engine.SpokeReport, hubLeaves, spokeLeaves map[string]engine.LeafField) []teraskyv1alpha1.ConversionRule {
+	hubPaths := dedupeSorted(sr.Uncovered.UncoveredHub)
+	spokePaths := dedupeSorted(sr.Uncovered.UncoveredSpoke)
+	usedHub := map[string]bool{}
+	usedSpoke := map[string]bool{}
+
+	var rules []teraskyv1alpha1.ConversionRule
+	for _, p := range hubPaths {
+		hl, okHub := hubLeaves[p]
+		sl, okSpoke := spokeLeaves[p]
+		if !okHub || !okSpoke || hl.Kind == sl.Kind {
+			continue
+		}
+		if !isScalarKind(hl.Kind) || !isScalarKind(sl.Kind) {
+			continue
+		}
+		usedHub[p] = true
+		usedSpoke[p] = true
+		rules = append(rules, teraskyv1alpha1.ConversionRule{
+			Strategy:   teraskyv1alpha1.StrategyTypeCoerce,
+			TypeCoerce: &teraskyv1alpha1.TypeCoerceParams{Path: p},
+		})
+	}
+
+	for _, c := range renameCandidates(hubPaths, spokePaths, hubLeaves, spokeLeaves) {
+		if usedHub[c.hubPath] || usedSpoke[c.spokePath] {
+			continue
+		}
+		usedHub[c.hubPath] = true
+		usedSpoke[c.spokePath] = true
+		rules = append(rules, teraskyv1alpha1.ConversionRule{
+			Strategy:    teraskyv1alpha1.StrategyFieldRename,
+			FieldRename: &teraskyv1alpha1.FieldRenameParams{HubPath: c.hubPath, SpokePath: c.spokePath},
+		})
+	}
+	return rules
+}
+
+type renameCandidate struct {
+	hubPath   string
+	spokePath string
+	score     float64
+}
+
+// renameCandidates scores every plausible hub/spoke pairing and returns
+// them best-first, so a greedy walk assigns the strongest matches before
+// weaker ones can steal a field. Pairs are only plausible when they share a
+// parent path and a FieldKind: a rename moves a field's name, not its
+// position in the tree or its type (that's what TypeCoerce is for).
+func renameCandidates(hubPaths, spokePaths []string, hubLeaves, spokeLeaves map[string]engine.LeafField) []renameCandidate {
+	var out []renameCandidate
+	for _, hp := range hubPaths {
+		hl, ok := hubLeaves[hp]
+		if !ok {
+			continue
+		}
+		for _, sp := range spokePaths {
+			if hp == sp {
+				continue
+			}
+			sl, ok := spokeLeaves[sp]
+			if !ok || sl.Kind != hl.Kind || sl.Opaque != hl.Opaque {
+				continue
+			}
+			if parentPath(hp) != parentPath(sp) {
+				continue
+			}
+			score := nameSimilarity(lastPathSegment(hp), lastPathSegment(sp))
+			if score < suggestSimilarityThreshold {
+				continue
+			}
+			out = append(out, renameCandidate{hubPath: hp, spokePath: sp, score: score})
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].score != out[j].score {
+			return out[i].score > out[j].score
+		}
+		if out[i].hubPath != out[j].hubPath {
+			return out[i].hubPath < out[j].hubPath
+		}
+		return out[i].spokePath < out[j].spokePath
+	})
+	return out
+}
+
+func isScalarKind(k engine.FieldKind) bool {
+	switch k {
+	case engine.FieldKindString, engine.FieldKindInteger, engine.FieldKindNumber, engine.FieldKindBoolean:
+		return true
+	}
+	return false
+}
+
+func parentPath(p string) string {
+	if i := strings.LastIndex(p, "."); i >= 0 {
+		return p[:i]
+	}
+	return ""
+}
+
+func lastPathSegment(p string) string {
+	if i := strings.LastIndex(p, "."); i >= 0 {
+		return p[i+1:]
+	}
+	return p
+}
+
+func dedupeSorted(in []string) []string {
+	seen := map[string]bool{}
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if seen[s] {
+			continue
+		}
+		seen[s] = true
+		out = append(out, s)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// nameSimilarity scores two field names between 0 and 1 by edit distance
+// over their normalized forms, so storageGB/storage_size/StorageSize all
+// compare on the letters that carry meaning rather than on casing or
+// punctuation an API author changed in passing.
+func nameSimilarity(a, b string) float64 {
+	na, nb := normalizeFieldName(a), normalizeFieldName(b)
+	if na == "" || nb == "" {
+		return 0
+	}
+	if na == nb {
+		return 1
+	}
+	longest := len(na)
+	if len(nb) > longest {
+		longest = len(nb)
+	}
+	return 1 - float64(levenshtein(na, nb))/float64(longest)
+}
+
+func normalizeFieldName(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			b.WriteRune(unicode.ToLower(r))
+		}
+	}
+	return b.String()
+}
+
+func levenshtein(a, b string) int {
+	prev := make([]int, len(b)+1)
+	cur := make([]int, len(b)+1)
+	for j := range prev {
+		prev[j] = j
+	}
+	for i := 1; i <= len(a); i++ {
+		cur[0] = i
+		for j := 1; j <= len(b); j++ {
+			cost := 1
+			if a[i-1] == b[j-1] {
+				cost = 0
+			}
+			cur[j] = min(prev[j]+1, min(cur[j-1]+1, prev[j-1]+cost))
+		}
+		prev, cur = cur, prev
+	}
+	return prev[len(b)]
+}
+
+func newSuggestCmd() *cobra.Command {
+	var xrdPath, crdPath, configPath, output string
+	cmd := &cobra.Command{
+		Use:   "suggest",
+		Short: "Propose rule stubs for fields no rule covers yet",
+		Long: `Analyze a conversion config, then propose rules for whatever it leaves
+uncovered — the tedious half of authoring a mapping between two versions.
+
+Hub and spoke fields that sit under the same parent, carry the same type, and
+have similar names are proposed as FieldRename rules. Fields that kept their
+path but changed scalar type are proposed as TypeCoerce rules.
+
+These are heuristics, not conclusions: nothing can prove two differently-named
+fields were meant to be the same one. Read every suggestion, delete the wrong
+ones, and let convctl validate and convctl test grade what's left. Strategies
+beyond rename and coerce are intentionally never guessed at.
+
+Output is shaped exactly like a config's spec.spokes stanza, so accepted
+suggestions merge in by hand with no reshaping.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			switch output {
+			case "yaml", "json":
+			default:
+				return fmt.Errorf("invalid --output value %q (want yaml or json)", output)
+			}
+			out, err := RunSuggest(xrdPath, crdPath, configPath)
+			if err != nil {
+				return err
+			}
+			if output == "json" {
+				return writeJSON(cmd, out)
+			}
+			if len(out.Spokes) == 0 {
+				_, err := fmt.Fprintln(cmd.OutOrStdout(), "# no suggestions: every uncovered field is either already claimed or too dissimilar to guess at")
+				return err
+			}
+			data, err := sigsyaml.Marshal(out)
+			if err != nil {
+				return fmt.Errorf("rendering YAML: %w", err)
+			}
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "# suggested rules — review every one before merging into spec.spokes")
+			_, err = cmd.OutOrStdout().Write(data)
+			return err
+		},
+	}
+	cmd.Flags().StringVarP(&xrdPath, "xrd", "x", "", "Path to an XRD YAML file (required for an XRDConversionConfig)")
+	cmd.Flags().StringVar(&crdPath, "crd", "", "Path to a CRD YAML file (required for a CRDConversionConfig)")
+	cmd.Flags().StringVarP(&configPath, "config", "c", "", "Path to an XRDConversionConfig or CRDConversionConfig YAML file (required)")
+	cmd.Flags().StringVarP(&output, "output", "o", "yaml", "Output format: yaml|json")
+	_ = cmd.MarkFlagRequired("config")
+	cmd.MarkFlagsOneRequired("xrd", "crd")
+	cmd.MarkFlagsMutuallyExclusive("xrd", "crd")
+	return cmd
+}

--- a/internal/cli/suggest_test.go
+++ b/internal/cli/suggest_test.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2026 The declarative-conversion-operator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"testing"
+
+	teraskyv1alpha1 "github.com/terasky-oss/declarative-conversion-operator/api/v1alpha1"
+)
+
+func spokeSuggestions(t *testing.T, out *SuggestOutput, version string) []teraskyv1alpha1.ConversionRule {
+	t.Helper()
+	for _, s := range out.Spokes {
+		if s.Version == version {
+			return s.Rules
+		}
+	}
+	t.Fatalf("expected suggestions for spoke %s, got %+v", version, out.Spokes)
+	return nil
+}
+
+func hasRename(rules []teraskyv1alpha1.ConversionRule, hubPath, spokePath string) bool {
+	for _, r := range rules {
+		if r.Strategy == teraskyv1alpha1.StrategyFieldRename && r.FieldRename != nil &&
+			r.FieldRename.HubPath == hubPath && r.FieldRename.SpokePath == spokePath {
+			return true
+		}
+	}
+	return false
+}
+
+func hasCoerce(rules []teraskyv1alpha1.ConversionRule, path string) bool {
+	for _, r := range rules {
+		if r.Strategy == teraskyv1alpha1.StrategyTypeCoerce && r.TypeCoerce != nil && r.TypeCoerce.Path == path {
+			return true
+		}
+	}
+	return false
+}
+
+// TestRunSuggest_ProposesRenamesAndCoerces runs against the full fixture's
+// schemas with every rule stripped, which is the situation suggest exists
+// for: the storageGB/storageSize rename the real config declares must come
+// back as a proposal, as must the priority type change.
+func TestRunSuggest_ProposesRenamesAndCoerces(t *testing.T) {
+	out, err := RunSuggest("testdata/full/xrd.yaml", "", "testdata/full/config-norules.yaml")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	v2 := spokeSuggestions(t, out, "v2")
+	if !hasRename(v2, "spec.storageGB", "spec.storageSize") {
+		t.Fatalf("expected a spec.storageGB -> spec.storageSize rename proposal, got %+v", v2)
+	}
+	if !hasRename(v2, "spec.memoryMB", "spec.memoryGB") {
+		t.Fatalf("expected a spec.memoryMB -> spec.memoryGB rename proposal, got %+v", v2)
+	}
+	if !hasCoerce(v2, "spec.priority") {
+		t.Fatalf("expected a spec.priority TypeCoerce proposal (integer on the hub, string on v2), got %+v", v2)
+	}
+}
+
+// TestRunSuggest_NeverProposesNoOpOrCrossTypeRenames guards the two ways a
+// name-similarity heuristic most easily embarrasses itself: proposing to
+// rename a field to itself, and proposing a rename across a type change
+// that no rename can actually perform.
+func TestRunSuggest_NeverProposesNoOpOrCrossTypeRenames(t *testing.T) {
+	out, err := RunSuggest("testdata/full/xrd.yaml", "", "testdata/full/config-norules.yaml")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, s := range out.Spokes {
+		for _, r := range s.Rules {
+			if r.FieldRename == nil {
+				continue
+			}
+			if r.FieldRename.HubPath == r.FieldRename.SpokePath {
+				t.Fatalf("spoke %s: proposed renaming %q to itself", s.Version, r.FieldRename.HubPath)
+			}
+		}
+		// dnsServers is an array on the hub and dnsServersCSV a string on
+		// v2: similar names, incompatible kinds, so no rename is valid.
+		if hasRename(s.Rules, "spec.dnsServers", "spec.dnsServersCSV") {
+			t.Fatalf("spoke %s: proposed a rename across an array/string type change", s.Version)
+		}
+	}
+}
+
+// TestRunSuggest_FullyCoveredConfigSuggestsNothing is the other end of the
+// range: the complete fixture leaves no field uncovered, so there is
+// nothing left to guess at.
+func TestRunSuggest_FullyCoveredConfigSuggestsNothing(t *testing.T) {
+	out, err := RunSuggest("testdata/full/xrd.yaml", "", "testdata/full/config.yaml")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(out.Spokes) != 0 {
+		t.Fatalf("expected no suggestions for a fully covered config, got %+v", out.Spokes)
+	}
+}
+
+func TestRunSuggest_WrongSchemaFlag(t *testing.T) {
+	if _, err := RunSuggest("", "testdata/crd.yaml", "testdata/config.yaml"); err == nil {
+		t.Fatalf("expected an error when an XRDConversionConfig is given --crd")
+	}
+	if _, err := RunSuggest("testdata/xrd.yaml", "", "testdata/crdconfig.yaml"); err == nil {
+		t.Fatalf("expected an error when a CRDConversionConfig is given --xrd")
+	}
+}
+
+func TestNameSimilarity(t *testing.T) {
+	cases := []struct {
+		a, b    string
+		atLeast float64
+	}{
+		{"storageGB", "storage_gb", 1},
+		{"memoryMB", "memoryGB", 0.8},
+		{"storageGB", "storageSize", suggestSimilarityThreshold},
+	}
+	for _, c := range cases {
+		if got := nameSimilarity(c.a, c.b); got < c.atLeast {
+			t.Errorf("nameSimilarity(%q, %q) = %v, want >= %v", c.a, c.b, got, c.atLeast)
+		}
+	}
+	if got := nameSimilarity("phase", "endpoints"); got >= suggestSimilarityThreshold {
+		t.Errorf("nameSimilarity(phase, endpoints) = %v, want below the suggestion threshold", got)
+	}
+	if got := nameSimilarity("", "anything"); got != 0 {
+		t.Errorf("nameSimilarity with an empty name = %v, want 0", got)
+	}
+}

--- a/internal/cli/test.go
+++ b/internal/cli/test.go
@@ -19,6 +19,9 @@ package cli
 import (
 	"context"
 	"fmt"
+	"os"
+	"runtime"
+	"sync"
 	"time"
 
 	internalwebhook "github.com/terasky-oss/declarative-conversion-operator/internal/webhook"
@@ -44,6 +47,30 @@ type TestOptions struct {
 	Live        bool
 	Kubeconfig  string
 	KubeContext string
+
+	// Concurrency is how many samples to test at once. Zero or negative
+	// means runtime.GOMAXPROCS(0). Testing a cluster's entire population
+	// of objects (Live) is embarrassingly parallel — every sample is
+	// independent, and the compiled Router is read-only once built.
+	Concurrency int
+	// Quiet suppresses the progress line written to stderr.
+	Quiet bool
+}
+
+// effectiveConcurrency clamps Concurrency to at least one worker, and to
+// no more workers than there are samples to give them.
+func (o TestOptions) effectiveConcurrency(samples int) int {
+	n := o.Concurrency
+	if n <= 0 {
+		n = runtime.GOMAXPROCS(0)
+	}
+	if n > samples {
+		n = samples
+	}
+	if n < 1 {
+		n = 1
+	}
+	return n
 }
 
 // RunTest loads the config, its target XRD or CRD, and samples, validates
@@ -198,28 +225,54 @@ func runTestCommon(opts TestOptions, resourceKind, resourceName, configName, hub
 	rep.Meta.ServedVersions = served
 	rep.Meta.GeneratedAt = nowRFC3339()
 
-	for _, s := range samples {
-		sr := SampleResult{File: s.File, AssertedVersion: s.Version}
-		for _, target := range targets {
-			if opts.SkipIdentity && target == s.Version {
-				continue
-			}
-			pr := testOnePath(router, hubVersion, lossyPaths, report, s, target, ruleUsage)
-			sr.Paths = append(sr.Paths, pr)
-			rep.Summary.PathsTested++
-			switch pr.Result {
-			case "pass":
-				rep.Summary.Pass++
-			case "loss":
-				rep.Summary.AcknowledgedLoss++
-			case "fail":
-				rep.Summary.UnacknowledgedLoss++
-			case "error":
-				rep.Summary.Errors++
-			}
+	// Samples are tested by a worker pool, but the results are collected
+	// by index and only appended to the Report afterwards, so the report
+	// a run produces never depends on how many workers produced it.
+	results := make([]SampleResult, len(samples))
+	var (
+		mu       sync.Mutex
+		done     int
+		next     = make(chan int)
+		wg       sync.WaitGroup
+		progress = !opts.Quiet && len(samples) > 1
+	)
+	go func() {
+		defer close(next)
+		for i := range samples {
+			next <- i
 		}
-		rep.Samples = append(rep.Samples, sr)
+	}()
+	for w := 0; w < opts.effectiveConcurrency(len(samples)); w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := range next {
+				sr, counts, usage := testOneSample(opts, router, hubVersion, lossyPaths, report, samples[i], targets)
+
+				mu.Lock()
+				results[i] = sr
+				rep.Summary.PathsTested += counts.pathsTested
+				rep.Summary.Pass += counts.pass
+				rep.Summary.AcknowledgedLoss += counts.acknowledgedLoss
+				rep.Summary.UnacknowledgedLoss += counts.unacknowledgedLoss
+				rep.Summary.Errors += counts.errors
+				for id, n := range usage {
+					ruleUsage[id] += n
+				}
+				done++
+				if progress {
+					_, _ = fmt.Fprintf(os.Stderr, "\rtested %d/%d samples", done, len(samples))
+				}
+				mu.Unlock()
+			}
+		}()
 	}
+	wg.Wait()
+	if progress {
+		_, _ = fmt.Fprintln(os.Stderr)
+	}
+
+	rep.Samples = results
 	rep.Summary.Samples = len(samples)
 
 	for _, sr := range report.SpokeReports {
@@ -231,6 +284,46 @@ func runTestCommon(opts TestOptions, resourceKind, resourceName, configName, hub
 
 	rep.Meta.DurationMs = float64(time.Since(start).Microseconds()) / 1000.0
 	return rep, nil
+}
+
+// sampleCounts is one sample's contribution to the report summary, tallied
+// inside a worker so the shared Report is touched exactly once per sample
+// rather than once per path.
+type sampleCounts struct {
+	pathsTested        int
+	pass               int
+	acknowledgedLoss   int
+	unacknowledgedLoss int
+	errors             int
+}
+
+// testOneSample runs one sample across every target version. Paths within
+// a sample stay sequential: they're cheap next to the coordination cost,
+// and keeping the unit of parallelism at the sample level is what makes
+// deterministic result ordering trivial.
+func testOneSample(opts TestOptions, router *engine.Router, hubVersion string, lossyPaths map[string]map[string]bool, report engine.AnalyzeReport, s Sample, targets []string) (SampleResult, sampleCounts, map[string]int) {
+	sr := SampleResult{File: s.File, AssertedVersion: s.Version}
+	var counts sampleCounts
+	usage := map[string]int{}
+	for _, target := range targets {
+		if opts.SkipIdentity && target == s.Version {
+			continue
+		}
+		pr := testOnePath(router, hubVersion, lossyPaths, report, s, target, usage)
+		sr.Paths = append(sr.Paths, pr)
+		counts.pathsTested++
+		switch pr.Result {
+		case "pass":
+			counts.pass++
+		case "loss":
+			counts.acknowledgedLoss++
+		case "fail":
+			counts.unacknowledgedLoss++
+		case "error":
+			counts.errors++
+		}
+	}
+	return sr, counts, usage
 }
 
 func ruleID(spokeVersion string, rr engine.RuleResult) string {

--- a/internal/cli/testdata/config-norename.yaml
+++ b/internal/cli/testdata/config-norename.yaml
@@ -1,0 +1,19 @@
+# testdata/config.yaml with its FieldRename rule dropped, so `convctl diff`
+# has a pair of configs differing in exactly one rule.
+apiVersion: terasky.com/v1alpha1
+kind: XRDConversionConfig
+metadata:
+  name: xfoos-conversion
+spec:
+  targetXRD:
+    name: xfoos.example.org
+  hubVersion: v2
+  spokes:
+    - version: v1
+      rules:
+        - strategy: Delete
+          delete:
+            path: spec.legacyDebugFlag
+            existsOn: Hub
+          acknowledgeLossy: true
+          reason: "not needed on v1"

--- a/internal/cli/testdata/full/config-norules.yaml
+++ b/internal/cli/testdata/full/config-norules.yaml
@@ -1,0 +1,14 @@
+# testdata/full/config.yaml with every rule stripped: the "I have a new
+# spoke version and no mapping yet" starting point `convctl suggest` exists
+# to bootstrap.
+apiVersion: terasky.com/v1alpha1
+kind: XRDConversionConfig
+metadata:
+  name: xwidgets-conversion
+spec:
+  targetXRD:
+    name: xwidgets.example.org
+  hubVersion: v3
+  spokes:
+    - version: v2
+    - version: v1

--- a/internal/cli/testdata/full/xrd.yaml
+++ b/internal/cli/testdata/full/xrd.yaml
@@ -4,6 +4,10 @@ metadata:
   name: xwidgets.example.org
 spec:
   scope: Namespaced
+  group: example.org
+  names:
+    kind: Widget
+    plural: xwidgets
   versions:
     - name: v3
       served: true

--- a/internal/cli/testdata/xrd.yaml
+++ b/internal/cli/testdata/xrd.yaml
@@ -4,6 +4,10 @@ metadata:
   name: xfoos.example.org
 spec:
   scope: Namespaced
+  group: example.org
+  names:
+    kind: Foo
+    plural: xfoos
   versions:
     - name: v2
       served: true

--- a/internal/controller/conversionwebhookserver_controller.go
+++ b/internal/controller/conversionwebhookserver_controller.go
@@ -187,6 +187,17 @@ func (r *ConversionWebhookServerReconciler) checkDefaultConflict(ctx context.Con
 	return nil
 }
 
+// toAnySlice widens a []string for embedding in an unstructured object,
+// whose contents must stay JSON-typed all the way down or its deep-copy
+// panics.
+func toAnySlice(ss []string) []any {
+	out := make([]any, len(ss))
+	for i, s := range ss {
+		out[i] = s
+	}
+	return out
+}
+
 func (r *ConversionWebhookServerReconciler) reconcileCertificate(ctx context.Context, server *teraskyv1alpha1.ConversionWebhookServer, namespace string) error {
 	dnsNames := server.Spec.Certificate.DNSNames
 	if len(dnsNames) == 0 {

--- a/internal/controller/crdconversionconfig_controller.go
+++ b/internal/controller/crdconversionconfig_controller.go
@@ -25,7 +25,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	applyextv1 "k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -40,6 +39,7 @@ import (
 
 	teraskyv1alpha1 "github.com/terasky-oss/declarative-conversion-operator/api/v1alpha1"
 	"github.com/terasky-oss/declarative-conversion-operator/internal/assign"
+	"github.com/terasky-oss/declarative-conversion-operator/internal/conversionpatch"
 	"github.com/terasky-oss/declarative-conversion-operator/internal/enqueue"
 	"github.com/terasky-oss/declarative-conversion-operator/internal/watchmap"
 	"github.com/terasky-oss/declarative-conversion-operator/pkg/crdadapter"
@@ -361,34 +361,21 @@ func (r *CRDConversionConfigReconciler) readCABundle(ctx context.Context, server
 // is a vendored core Kubernetes type, unlike the Crossplane XRD this
 // mirrors) with a field manager scoped to exactly that field.
 func (r *CRDConversionConfigReconciler) applyConversionPatch(ctx context.Context, cfg *teraskyv1alpha1.CRDConversionConfig, serviceNamespace, serviceName, path string, port int32, caBundle string, reviewVersions []string) error {
-	caBundleBytes, err := base64.StdEncoding.DecodeString(caBundle)
+	patch, err := conversionpatch.BuildCRDConversionPatch(conversionpatch.Params{
+		TargetName: cfg.Spec.TargetCRD.Name, ConfigName: cfg.Name, PlanHash: cfg.Status.SchemaHash,
+		ServiceName: serviceName, ServiceNamespace: serviceNamespace, Path: path, Port: port,
+		CABundle: caBundle, ReviewVersions: reviewVersions,
+	})
 	if err != nil {
-		return fmt.Errorf("decoding CA bundle: %w", err)
+		return err
 	}
-	patch := applyextv1.CustomResourceDefinition(cfg.Spec.TargetCRD.Name).
-		WithAnnotations(map[string]string{
-			"conversion.terasky.com/managed-by": cfg.Name,
-			"conversion.terasky.com/plan-hash":  cfg.Status.SchemaHash,
-		}).
-		WithSpec(applyextv1.CustomResourceDefinitionSpec().
-			WithConversion(applyextv1.CustomResourceConversion().
-				WithStrategy(extv1.WebhookConverter).
-				WithWebhook(applyextv1.WebhookConversion().
-					WithClientConfig(applyextv1.WebhookClientConfig().
-						WithService(applyextv1.ServiceReference().
-							WithName(serviceName).WithNamespace(serviceNamespace).WithPath(path).WithPort(port)).
-						WithCABundle(caBundleBytes...)).
-					WithConversionReviewVersions(reviewVersions...))))
 	return r.Apply(ctx, patch, client.ForceOwnership, client.FieldOwner(FieldOwner))
 }
 
 // revertCRD resets spec.conversion to strategy=None, relinquishing this
 // operator's ownership of the field.
 func (r *CRDConversionConfigReconciler) revertCRD(ctx context.Context, crdName string) error {
-	patch := applyextv1.CustomResourceDefinition(crdName).
-		WithSpec(applyextv1.CustomResourceDefinitionSpec().
-			WithConversion(applyextv1.CustomResourceConversion().WithStrategy(extv1.NoneConverter)))
-	return r.Apply(ctx, patch, client.ForceOwnership, client.FieldOwner(FieldOwner))
+	return r.Apply(ctx, conversionpatch.BuildCRDRevertPatch(crdName), client.ForceOwnership, client.FieldOwner(FieldOwner))
 }
 
 // reconcileDelete implements the same safe-revert flow as

--- a/internal/controller/xrdconversionconfig_controller.go
+++ b/internal/controller/xrdconversionconfig_controller.go
@@ -39,6 +39,7 @@ import (
 
 	teraskyv1alpha1 "github.com/terasky-oss/declarative-conversion-operator/api/v1alpha1"
 	"github.com/terasky-oss/declarative-conversion-operator/internal/assign"
+	"github.com/terasky-oss/declarative-conversion-operator/internal/conversionpatch"
 	"github.com/terasky-oss/declarative-conversion-operator/internal/enqueue"
 	"github.com/terasky-oss/declarative-conversion-operator/internal/watchmap"
 	"github.com/terasky-oss/declarative-conversion-operator/pkg/engine"
@@ -441,56 +442,18 @@ func (r *XRDConversionConfigReconciler) readCABundle(ctx context.Context, server
 // manager scoped to exactly those fields so this operator never fights any
 // other owner of the XRD's spec.
 func (r *XRDConversionConfigReconciler) applyConversionPatch(ctx context.Context, cfg *teraskyv1alpha1.XRDConversionConfig, serviceNamespace, serviceName, path string, port int32, caBundle string, reviewVersions []string) error {
-	patch := &unstructured.Unstructured{Object: map[string]any{
-		"apiVersion": xrdadapter.GroupVersionKind.GroupVersion().String(),
-		"kind":       xrdadapter.GroupVersionKind.Kind,
-		"metadata": map[string]any{
-			"name": cfg.Spec.TargetXRD.Name,
-			"annotations": map[string]any{
-				"conversion.terasky.com/managed-by": cfg.Name,
-				"conversion.terasky.com/plan-hash":  cfg.Status.SchemaHash,
-			},
-		},
-		"spec": map[string]any{
-			"conversion": map[string]any{
-				"strategy": "Webhook",
-				"webhook": map[string]any{
-					"clientConfig": map[string]any{
-						"service": map[string]any{
-							"name":      serviceName,
-							"namespace": serviceNamespace,
-							"path":      path,
-							"port":      int64(port),
-						},
-						"caBundle": caBundle,
-					},
-					"conversionReviewVersions": toAnySlice(reviewVersions),
-				},
-			},
-		},
-	}}
+	patch := conversionpatch.BuildXRDConversionPatch(conversionpatch.Params{
+		TargetName: cfg.Spec.TargetXRD.Name, ConfigName: cfg.Name, PlanHash: cfg.Status.SchemaHash,
+		ServiceName: serviceName, ServiceNamespace: serviceNamespace, Path: path, Port: port,
+		CABundle: caBundle, ReviewVersions: reviewVersions,
+	})
 	return r.Apply(ctx, client.ApplyConfigurationFromUnstructured(patch), client.ForceOwnership, client.FieldOwner(FieldOwner))
-}
-
-func toAnySlice(ss []string) []any {
-	out := make([]any, len(ss))
-	for i, s := range ss {
-		out[i] = s
-	}
-	return out
 }
 
 // revertXRD resets spec.conversion to strategy=None, relinquishing this
 // operator's ownership of the field.
 func (r *XRDConversionConfigReconciler) revertXRD(ctx context.Context, xrdName string) error {
-	patch := &unstructured.Unstructured{Object: map[string]any{
-		"apiVersion": xrdadapter.GroupVersionKind.GroupVersion().String(),
-		"kind":       xrdadapter.GroupVersionKind.Kind,
-		"metadata":   map[string]any{"name": xrdName},
-		"spec": map[string]any{
-			"conversion": map[string]any{"strategy": "None"},
-		},
-	}}
+	patch := conversionpatch.BuildXRDRevertPatch(xrdName)
 	return r.Apply(ctx, client.ApplyConfigurationFromUnstructured(patch), client.ForceOwnership, client.FieldOwner(FieldOwner))
 }
 

--- a/internal/conversionpatch/conversionpatch.go
+++ b/internal/conversionpatch/conversionpatch.go
@@ -1,0 +1,159 @@
+/*
+Copyright 2026 The declarative-conversion-operator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package conversionpatch builds the server-side-apply patches that point
+// an XRD's or CRD's spec.conversion at a webhook server.
+//
+// These are pure functions of their inputs with no client and no context,
+// so the exact object the operator would apply can be rendered offline —
+// that's what backs `convctl patch-preview`. The controllers call the same
+// builders they always did, they just no longer own the construction.
+package conversionpatch
+
+import (
+	"encoding/base64"
+	"fmt"
+
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	applyextv1 "k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/terasky-oss/declarative-conversion-operator/pkg/xrdadapter"
+)
+
+// The annotations the operator stamps alongside spec.conversion, recording
+// which config owns the patch and which compiled plan it reflects.
+const (
+	ManagedByAnnotation = "conversion.terasky.com/managed-by"
+	PlanHashAnnotation  = "conversion.terasky.com/plan-hash"
+)
+
+// Params is everything a conversion patch needs. It deliberately takes
+// already-resolved values (a service name, not a server name) so the
+// builders stay free of both cluster lookups and the operator's own naming
+// conventions.
+type Params struct {
+	// TargetName is the XRD's or CRD's metadata.name.
+	TargetName string
+	// ConfigName is the XRDConversionConfig/CRDConversionConfig that owns
+	// this patch, recorded in the managed-by annotation.
+	ConfigName string
+	// PlanHash is the config's schema hash, recorded in the plan-hash
+	// annotation.
+	PlanHash string
+
+	ServiceName      string
+	ServiceNamespace string
+	Path             string
+	Port             int32
+	// CABundle is base64-encoded, matching how it is read out of the
+	// cert-manager Secret and how a CRD's YAML spells it.
+	CABundle       string
+	ReviewVersions []string
+}
+
+// BuildXRDConversionPatch renders the SSA patch that points a Crossplane
+// XRD's spec.conversion at the webhook server. Crossplane's XRD type isn't
+// vendored here, so this stays unstructured — the exact shape the
+// controller has always applied.
+func BuildXRDConversionPatch(p Params) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": xrdadapter.GroupVersionKind.GroupVersion().String(),
+		"kind":       xrdadapter.GroupVersionKind.Kind,
+		"metadata": map[string]any{
+			"name": p.TargetName,
+			// map[string]any, not map[string]string: everything inside an
+			// unstructured.Unstructured has to stay JSON-typed or its
+			// deep-copy panics.
+			"annotations": map[string]any{
+				ManagedByAnnotation: p.ConfigName,
+				PlanHashAnnotation:  p.PlanHash,
+			},
+		},
+		"spec": map[string]any{
+			"conversion": map[string]any{
+				"strategy": "Webhook",
+				"webhook": map[string]any{
+					"clientConfig": map[string]any{
+						"service": map[string]any{
+							"name":      p.ServiceName,
+							"namespace": p.ServiceNamespace,
+							"path":      p.Path,
+							"port":      int64(p.Port),
+						},
+						"caBundle": p.CABundle,
+					},
+					"conversionReviewVersions": toAnySlice(p.ReviewVersions),
+				},
+			},
+		},
+	}}
+}
+
+// BuildCRDConversionPatch is BuildXRDConversionPatch's sibling for a native
+// CustomResourceDefinition, which — being a vendored core Kubernetes type —
+// gets a typed apply configuration instead of an unstructured object. Fails
+// on a CA bundle that isn't valid base64, since the typed API takes raw
+// bytes.
+func BuildCRDConversionPatch(p Params) (*applyextv1.CustomResourceDefinitionApplyConfiguration, error) {
+	caBundleBytes, err := base64.StdEncoding.DecodeString(p.CABundle)
+	if err != nil {
+		return nil, fmt.Errorf("decoding CA bundle: %w", err)
+	}
+	return applyextv1.CustomResourceDefinition(p.TargetName).
+		WithAnnotations(map[string]string{
+			ManagedByAnnotation: p.ConfigName,
+			PlanHashAnnotation:  p.PlanHash,
+		}).
+		WithSpec(applyextv1.CustomResourceDefinitionSpec().
+			WithConversion(applyextv1.CustomResourceConversion().
+				WithStrategy(extv1.WebhookConverter).
+				WithWebhook(applyextv1.WebhookConversion().
+					WithClientConfig(applyextv1.WebhookClientConfig().
+						WithService(applyextv1.ServiceReference().
+							WithName(p.ServiceName).WithNamespace(p.ServiceNamespace).WithPath(p.Path).WithPort(p.Port)).
+						WithCABundle(caBundleBytes...)).
+					WithConversionReviewVersions(p.ReviewVersions...)))), nil
+}
+
+// BuildXRDRevertPatch renders the patch that resets an XRD's
+// spec.conversion to strategy=None, relinquishing this operator's
+// ownership of the field.
+func BuildXRDRevertPatch(targetName string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": xrdadapter.GroupVersionKind.GroupVersion().String(),
+		"kind":       xrdadapter.GroupVersionKind.Kind,
+		"metadata":   map[string]any{"name": targetName},
+		"spec": map[string]any{
+			"conversion": map[string]any{"strategy": "None"},
+		},
+	}}
+}
+
+// BuildCRDRevertPatch is BuildXRDRevertPatch's sibling for a native CRD.
+func BuildCRDRevertPatch(targetName string) *applyextv1.CustomResourceDefinitionApplyConfiguration {
+	return applyextv1.CustomResourceDefinition(targetName).
+		WithSpec(applyextv1.CustomResourceDefinitionSpec().
+			WithConversion(applyextv1.CustomResourceConversion().WithStrategy(extv1.NoneConverter)))
+}
+
+func toAnySlice(ss []string) []any {
+	out := make([]any, len(ss))
+	for i, s := range ss {
+		out[i] = s
+	}
+	return out
+}

--- a/internal/conversionpatch/conversionpatch_test.go
+++ b/internal/conversionpatch/conversionpatch_test.go
@@ -1,0 +1,155 @@
+/*
+Copyright 2026 The declarative-conversion-operator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conversionpatch
+
+import (
+	"encoding/base64"
+	"reflect"
+	"testing"
+
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func testParams() Params {
+	return Params{
+		TargetName:       "xwidgets.example.org",
+		ConfigName:       "xwidgets-conversion",
+		PlanHash:         "sha256:abc",
+		ServiceName:      "prod-webhook-server",
+		ServiceNamespace: "conversion-system",
+		Path:             "/convert/xwidgets.example.org",
+		Port:             8443,
+		CABundle:         base64.StdEncoding.EncodeToString([]byte("PEM")),
+		ReviewVersions:   []string{"v1", "v1beta1"},
+	}
+}
+
+func TestBuildXRDConversionPatch(t *testing.T) {
+	patch := BuildXRDConversionPatch(testParams())
+
+	if got := patch.GetAPIVersion(); got != "apiextensions.crossplane.io/v2" {
+		t.Fatalf("apiVersion = %q", got)
+	}
+	if got := patch.GetKind(); got != "CompositeResourceDefinition" {
+		t.Fatalf("kind = %q", got)
+	}
+	if got := patch.GetName(); got != "xwidgets.example.org" {
+		t.Fatalf("name = %q", got)
+	}
+	wantAnnotations := map[string]string{
+		ManagedByAnnotation: "xwidgets-conversion",
+		PlanHashAnnotation:  "sha256:abc",
+	}
+	if got := patch.GetAnnotations(); !reflect.DeepEqual(got, wantAnnotations) {
+		t.Fatalf("annotations = %v, want %v", got, wantAnnotations)
+	}
+
+	strategy, found, err := unstructured.NestedString(patch.Object, "spec", "conversion", "strategy")
+	if err != nil || !found || strategy != "Webhook" {
+		t.Fatalf("spec.conversion.strategy = %q (found=%v, err=%v)", strategy, found, err)
+	}
+	svc, found, err := unstructured.NestedMap(patch.Object, "spec", "conversion", "webhook", "clientConfig", "service")
+	if err != nil || !found {
+		t.Fatalf("service block missing: found=%v err=%v", found, err)
+	}
+	want := map[string]any{
+		"name":      "prod-webhook-server",
+		"namespace": "conversion-system",
+		"path":      "/convert/xwidgets.example.org",
+		"port":      int64(8443),
+	}
+	if !reflect.DeepEqual(svc, want) {
+		t.Fatalf("service = %#v, want %#v", svc, want)
+	}
+	ca, _, _ := unstructured.NestedString(patch.Object, "spec", "conversion", "webhook", "clientConfig", "caBundle")
+	if ca != testParams().CABundle {
+		t.Fatalf("caBundle = %q, want the base64 input verbatim", ca)
+	}
+	versions, _, err := unstructured.NestedStringSlice(patch.Object, "spec", "conversion", "webhook", "conversionReviewVersions")
+	if err != nil {
+		t.Fatalf("conversionReviewVersions is not a string slice: %v", err)
+	}
+	if !reflect.DeepEqual(versions, []string{"v1", "v1beta1"}) {
+		t.Fatalf("conversionReviewVersions = %v", versions)
+	}
+
+	// An unstructured patch whose leaves aren't JSON-typed panics the
+	// moment controller-runtime deep-copies it on the way to the API
+	// server, so prove it survives that round trip here rather than in
+	// production.
+	_ = patch.DeepCopy()
+}
+
+func TestBuildCRDConversionPatch(t *testing.T) {
+	patch, err := BuildCRDConversionPatch(testParams())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if patch.Name == nil || *patch.Name != "xwidgets.example.org" {
+		t.Fatalf("name = %v", patch.Name)
+	}
+	if patch.Kind == nil || *patch.Kind != "CustomResourceDefinition" {
+		t.Fatalf("kind = %v", patch.Kind)
+	}
+	if got := patch.Annotations[ManagedByAnnotation]; got != "xwidgets-conversion" {
+		t.Fatalf("managed-by annotation = %q", got)
+	}
+	conv := patch.Spec.Conversion
+	if conv == nil || conv.Strategy == nil || *conv.Strategy != extv1.WebhookConverter {
+		t.Fatalf("conversion strategy = %+v", conv)
+	}
+	svc := conv.Webhook.ClientConfig.Service
+	if *svc.Name != "prod-webhook-server" || *svc.Namespace != "conversion-system" || *svc.Port != 8443 {
+		t.Fatalf("service = %+v", svc)
+	}
+	// The typed API takes raw bytes, so the base64 input must have been
+	// decoded on the way in.
+	if string(conv.Webhook.ClientConfig.CABundle) != "PEM" {
+		t.Fatalf("caBundle = %q, want the decoded bytes", conv.Webhook.ClientConfig.CABundle)
+	}
+	if !reflect.DeepEqual(conv.Webhook.ConversionReviewVersions, []string{"v1", "v1beta1"}) {
+		t.Fatalf("conversionReviewVersions = %v", conv.Webhook.ConversionReviewVersions)
+	}
+}
+
+func TestBuildCRDConversionPatch_RejectsNonBase64CABundle(t *testing.T) {
+	p := testParams()
+	p.CABundle = "-----BEGIN CERTIFICATE-----"
+	if _, err := BuildCRDConversionPatch(p); err == nil {
+		t.Fatalf("expected an error for a CA bundle that isn't base64")
+	}
+}
+
+func TestBuildRevertPatches(t *testing.T) {
+	xrd := BuildXRDRevertPatch("xwidgets.example.org")
+	strategy, found, err := unstructured.NestedString(xrd.Object, "spec", "conversion", "strategy")
+	if err != nil || !found || strategy != "None" {
+		t.Fatalf("XRD revert strategy = %q (found=%v, err=%v)", strategy, found, err)
+	}
+	if _, found, _ := unstructured.NestedMap(xrd.Object, "spec", "conversion", "webhook"); found {
+		t.Fatalf("expected a revert patch to carry no webhook block at all")
+	}
+
+	crd := BuildCRDRevertPatch("widgets.example.org")
+	if crd.Spec.Conversion == nil || *crd.Spec.Conversion.Strategy != extv1.NoneConverter {
+		t.Fatalf("CRD revert strategy = %+v", crd.Spec.Conversion)
+	}
+	if crd.Spec.Conversion.Webhook != nil {
+		t.Fatalf("expected a revert patch to carry no webhook block at all")
+	}
+}

--- a/pkg/engine/schema.go
+++ b/pkg/engine/schema.go
@@ -90,6 +90,15 @@ type LeafField struct {
 	Required bool
 }
 
+// FlattenSchema walks schema and returns every leaf field it can address,
+// with the kind and required-ness the engine's own coverage analysis uses.
+// Exported for tooling that has to reason about uncovered fields in the
+// same terms Analyze does — notably convctl's rule-stub suggester, which
+// needs a leaf's FieldKind to tell a rename apart from a type coercion.
+func FlattenSchema(schema *extv1.JSONSchemaProps) []LeafField {
+	return flattenSchema(schema)
+}
+
 // flattenSchema walks schema and returns every leaf field it can address,
 // recursing into structured objects and stopping (marking Opaque) at maps
 // with no statically-known key set.


### PR DESCRIPTION
## Summary
Implements Epic Phase 4 — authors can design and prove conversions offline with `convctl` before mutating cluster XRDs/CRDs.

Stacked on #100 (`phase-3/observability-pack`). Merge Phase 3 first; this PR then merges cleanly onto `main`.

- **4.1** `convctl diff` — config coverage/claim/lossy deltas (two configs or `--live`)
- **4.2** `convctl convert` — one-shot hub↔spoke object transform
- **4.3** `convctl suggest` — analyze-assisted `fieldRename`/`typeCoerce` stubs
- **4.4** Clarified `--fail-on` semantics + full exit-code matrix in docs/tests
- **4.5** Parallel `--live`/`test` sample workers (`--concurrency`, `--quiet`)
- **4.6** `convctl patch-preview` + shared SSA conversion patch builders

Closes #36
Closes #37
Closes #38
Closes #39
Closes #40
Closes #41
Closes #42

## Test plan
- [x] `go test ./internal/cli/... ./internal/controller/... ./internal/conversionpatch/... ./pkg/engine/...`
- [x] CI green against Phase 3 base
- [x] Code review feedback triaged